### PR TITLE
Fix corner cases by unifying escaping/unescaping

### DIFF
--- a/test/htm.test.js
+++ b/test/htm.test.js
@@ -1,0 +1,38 @@
+
+const htm = require('htm');
+
+const html = htm.bind((tag, props, ...children) => ({ tag, props, children }));
+
+describe('htm', () => {
+	test('preserves value case', () => {
+		expect(html`<div id=Hello />`).toEqual({
+			tag: 'div',
+			props: { id: 'Hello' },
+			children: []
+		});
+	});
+
+	test('preserves placeholder-looking strings in attributes and text', () => {
+		expect(html`<div $_=$_a>$_[1]`).toEqual({
+			tag: 'div',
+			props: { $_: '$_a' },
+			children: ['$_[1]']
+		});
+	});
+
+	test('preserves underscores in tags, attributes and text', () => {
+		expect(html`<tag_name attr_key=attr_value>text_value`).toEqual({
+			tag: 'tag_name',
+			props: { attr_key: 'attr_value' },
+			children: ['text_value']
+		});
+	});
+
+	test('escapes attribute names with allowed special characters', () => {
+		expect(html`<div attr\\=hello />`).toEqual({
+			tag: 'div',
+			props: { 'attr\\': 'hello' },
+			children: []
+		});
+	});
+});

--- a/test/preact.test.js
+++ b/test/preact.test.js
@@ -113,7 +113,7 @@ describe('performance', () => {
 		let count = 0;
 		function go(count) {
 			return html(
-				statics.concat(['count:', count]),
+				statics.concat(['count:', ''+count]),
 				`id${count}`,
 				html(['<li data-id="','">', '</li>'], 'i'+count, 'some text #'+count),
 				Foo, Foo, Foo


### PR DESCRIPTION
This pull request addresses some corner cases and adds tests for those cases:

 * `<div>$_h[1]</div>` gets transformed to `h("div",{},[]);`
 * Static attribute values that contain upper-case characters get mangled, e.g. `<div id=Hello>` gets transformed to `h(\"div\",{id:\":::Hello\"},[]);`
 * I'm not too sure about this, but based on [this HTML spec](https://www.w3.org/TR/2012/WD-html-markup-20120320/syntax.html#attribute-name) attribute names can theoretically contain characters such as `\`, which can get transformed into malformed code.

These problems were partially caused by the way how e.g. upper-case characters in attributes are escaped before being fed to the browser's HTML parser and how they couldn't be unambigiously unescaped back later. Therefore this patch modifies placeholder handling and escaping:

 1. In statics underscore and upper-case characters get prefixed with `$_` (so e.g. `A` becomes `$_A`).
 1. Variables get transformed to `$_[<number>]` (e.g. `$_[1]`) instead of `$_h[<number>]` to separate them from potentially lower-cased `$_H`.
 1. Attribute names containing a placeholder tag name is `$_` instead of `c@` so the complete string would be `$_=<something>`.

Cases 2. and 3. are handled as previously, and case 1. gets reversed in the end - the idea being that in the end every substring that matches `/\$_[_A-Z]/i` can be safely and unambiguously turned back into an underscore or upper-case character. Attribute names also get escaped with `JSON.stringify`.

These changes do not seem to materially affect the performance in my environment, but of course YMMV. As a bonus the gzipped builds seem to be a tad smaller (671 B for htm.mjs.gz, down from 688 B).

There's also a minor change to preact.test.js, as the new code assumes that the statics that get passed in are always strings. I think this is a valid assumption..?