### PR TITLE
Use unique keys for caching results

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -18,7 +18,11 @@ const TEMPLATE = document.createElement('template');
 const reg = /(\$_h\[\d+\])/g;
 
 export default function html(statics) {
-	const tpl = CACHE[statics] || (CACHE[statics] = build(statics));
+	let key = '', i = 0;
+	while (i < statics.length) {
+		key += statics[i].length + '$' + statics[i++];
+	}
+	const tpl = CACHE[key] || (CACHE[key] = build(statics));
 	// eslint-disable-next-line prefer-rest-params
 	return tpl(this, arguments);
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -18,10 +18,7 @@ const TEMPLATE = document.createElement('template');
 const reg = /(\$_h\[\d+\])/g;
 
 export default function html(statics) {
-	let key = '', i = 0;
-	while (i < statics.length) {
-		key += statics[i].length + '$' + statics[i++];
-	}
+	const key = statics.reduce((key, s) => key + s.length + '$' + s, '');
 	const tpl = CACHE[key] || (CACHE[key] = build(statics));
 	// eslint-disable-next-line prefer-rest-params
 	return tpl(this, arguments);

--- a/test/babel.test.js
+++ b/test/babel.test.js
@@ -18,6 +18,26 @@ describe('htm/babel', () => {
 		).toBe(`h("div",{id:"hello"},["hello"]);`);
 	});
 
+	test('cache key should be unique', () => {
+		transform('html`<div>Hello, World!</div>`;', {
+			babelrc: false,
+			compact: true,
+			plugins: [
+				htmBabelPlugin
+			]
+		});
+
+		expect(
+			transform('html`<div>Hello${comma} World!</div>`;', {
+				babelrc: false,
+				compact: true,
+				plugins: [
+					htmBabelPlugin
+				]
+			}).code
+		).toBe(`h("div",{},["Hello",comma," World!"]);`);
+	});
+
 	test('basic transformation with variable', () => {
 		expect(
 			transform('var name="world";html`<div id=hello>hello, ${name}</div>`;', {

--- a/test/preact.test.js
+++ b/test/preact.test.js
@@ -113,7 +113,7 @@ describe('performance', () => {
 		let count = 0;
 		function go(count) {
 			return html(
-				statics.concat(['count:', count]),
+				statics.concat(['count:', ''+count]),
 				`id${count}`,
 				html(['<li data-id="','">', '</li>'], 'i'+count, 'some text #'+count),
 				Foo, Foo, Foo


### PR DESCRIPTION
Currently the results for parsed templates get cached, the cache key being the statics joined with `,`. It's possible to accidentally have two different tagged templates that have the same cache key. For example `<div>Hello, World!</div>` and `<div>Hello${comma} World!</div>` would both have `<div>Hello, World!</div>` as their cache key.

This pull request attemps to fix that and add a relevant test. Cache keys are now created by prefixing underscores and commas in statics by with an additional underscore `_`, and then joining these modified statics. This should (?) ensure that cache keys are unique. The cache object is also now created via `Object.create(null)` to ensure that it doesn't have a prototype and therefore keys like `hasOwnProperty` defined.

Unfortunately this affects the performance. Max. impact seems to be 5% slowdown in my development environment. The bundle size is also larger: Merged to the current master htm.mjs.gz takes 715 B, up from 688 B. When merged to #21 htm.mjs.gz takes 696 B.