### PR TITLE
Fix field->code transformation in some corner cases

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -45,7 +45,7 @@ function build(statics) {
 /** Traverse a DOM tree and serialize it to hyperscript function calls */
 function walk(n) {
 	if (n.nodeType != 1) {
-		if (n.nodeType == 3 && n.data) return field(n.data, ',');
+		if (n.nodeType == 3 && n.data) return `[${field(n.data)}]`;
 		return 'null';
 	}
 	let str = '',
@@ -79,13 +79,9 @@ function walk(n) {
 
 /** Serialize a field to a String or reference for use in generated code. */
 function field(value, sep) {
-	const pieces = value.split(reg);
-	if (pieces[1] === value) {
-		return value;
-	}
-	for (let i = 0; i < pieces.length; i += 2) {
-		pieces[i] = JSON.stringify(pieces[i]);
-	}
-	const strValue = pieces.join(sep);
-	return sep == ',' ? `[${strValue}]` : strValue;
+	return value
+		.split(reg)
+		.map((piece, i) => i % 2 ? piece : (piece && JSON.stringify(piece)))
+		.filter(piece => piece)
+		.join(sep);
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -79,12 +79,13 @@ function walk(n) {
 
 /** Serialize a field to a String or reference for use in generated code. */
 function field(value, sep) {
-	const matches = value.match(reg);
-	let strValue = JSON.stringify(value);
-	if (matches != null) {
-		if (matches[0] === value) return value;
-		strValue = strValue.replace(reg, `"${sep}$1${sep}"`).replace(/"[+,]"/g, '');
-		if (sep == ',') strValue = `[${strValue}]`;
+	const pieces = value.split(reg);
+	if (pieces[1] === value) {
+		return value;
 	}
-	return strValue;
+	for (let i = 0; i < pieces.length; i += 2) {
+		pieces[i] = JSON.stringify(pieces[i]);
+	}
+	const strValue = pieces.join(sep);
+	return sep == ',' ? `[${strValue}]` : strValue;
 }

--- a/test/babel.test.js
+++ b/test/babel.test.js
@@ -57,4 +57,16 @@ describe('htm/babel', () => {
 			}).code
 		).toBe(`var name="world",vnode={type:1,tag:"div",props:{id:"hello"},children:[{type:3,tag:null,props:null,children:null,text:"hello, "},name],text:null};`);
 	});
+
+	test('produce valid code for valid templates', () => {
+		expect(
+			transform('html`<div>",${name}</div>`;', {
+				babelrc: false,
+				compact: true,
+				plugins: [
+					htmBabelPlugin
+				]
+			}).code
+		).toBe(`h("div",{},["\\",",name]);`);
+	});
 });


### PR DESCRIPTION
In *src/index.mjs* fields are serialized to generated code. The transformation can in some cases produce malformed code. This pull request fixes the serialization function and and adds a relevant test.

An example of a problematic case is `<div>",${name}</div>`, where the expected output is something like `h("div",{},["\\",",name]);`. However, the post-processing step in the serialization function gets rid of the substring `","` in the middle, resulting in malformed code.

The fix is to first split the serialized value to alternating static and dynamic pieces and then stringify only the static ones.

The fixed *index.mjs* is a bit smaller gzipped, 683 B against master's 688 B. In my environment the performance seems to stay the same.