### PR TITLE
Fix babel-plugin-htm's escaping

### DIFF
--- a/test/babel.test.js
+++ b/test/babel.test.js
@@ -57,4 +57,16 @@ describe('htm/babel', () => {
 			}).code
 		).toBe(`var name="world",vnode={type:1,tag:"div",props:{id:"hello"},children:[{type:3,tag:null,props:null,children:null,text:"hello, "},name],text:null};`);
 	});
+
+	test('preserves placeholder-looking strings in attributes and text', () => {
+		expect(
+			transform('html`<div $_[1]=$_[2]>$_[3]`;', {
+				babelrc: false,
+				compact: true,
+				plugins: [
+					htmBabelPlugin
+				]
+			}).code
+		).toBe(`h("div",{"$_[1]":"$_[2]"},["$_[3]"]);`);
+	});
 });


### PR DESCRIPTION
The Babel plugin can, in some cases, return unexpected values due to how it temporarily replaces variables with placeholders of form `$$$_h_[<number>]`. An example of a problematic input is `<div>$$$_h_[1]</div>` that gets transformed to `h("div",{},[]);` when the expected result is `h("div",{},["$$$_h_[1]"]);`.

This pull request fixes this behavior by partially reusing the same trick as in #21, namely escaping all underscores in statics to `$__` and all variables to `$_[<number>]` and unescaping in the end accordingly.

It should be noted that the prefix `$_` doesn't have to unique, and `$_` can appear in the original template. In the escaped text the variable placeholders will be the only appearances of `$_` that are immediately followed some other character than an underscore. This also allows us unescape things prefixed with `$_` back unambiguously. The added test demonstrates such a case.

The changes in this pull request were originally a part of #21, but separated for better reviewability.