### PR TITLE
Fix some corner cases in the custom JSX parser and add tests

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -177,6 +177,7 @@ function build(input) {
 					// <a disabled>
 					if (inTag) {
 						commit();
+						mode = MODE_WHITESPACE;
 						continue;
 					}
 			}

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -75,7 +75,7 @@ function build(input) {
 			else if (propName) {
 				if (!spread) out += ',';
 				if (propCount === 0) out += '({';
-				out += propName + ':';
+				out += JSON.stringify(propName) + ':';
 				out += field || ((propHasValue || buffer) && JSON.stringify(buffer)) || 'true';
 				propName = '';
 				spread = false;

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -52,6 +52,10 @@ describe('htm', () => {
 	test('single prop with static value', () => {
 		expect(html`<a href="/hello" />`).toEqual({ tag: 'a', props: { href: '/hello' }, children: [] });
 	});
+	
+	test('single prop with static value followed by a single boolean prop', () => {
+		expect(html`<a href="/hello" b />`).toEqual({ tag: 'a', props: { href: '/hello', b: true }, children: [] });
+	});
 
 	test('two props with static values', () => {
 		expect(html`<a href="/hello" target="_blank" />`).toEqual({ tag: 'a', props: { href: '/hello', target: '_blank' }, children: [] });
@@ -75,6 +79,9 @@ describe('htm', () => {
 		expect(html`<a b ...${{ foo: 'bar' }} />`).toEqual({ tag: 'a', props: { b: true, foo: 'bar' }, children: [] });
 		expect(html`<a b c ...${{ foo: 'bar' }} />`).toEqual({ tag: 'a', props: { b: true, c: true, foo: 'bar' }, children: [] });
 		expect(html`<a ...${{ foo: 'bar' }} b />`).toEqual({ tag: 'a', props: { b: true, foo: 'bar' }, children: [] });
+		expect(html`<a b="1" ...${{ foo: 'bar' }} />`).toEqual({ tag: 'a', props: { b: '1', foo: 'bar' }, children: [] });
+		expect(html`<a x="1"><b y="2" ...${{ c: 'bar' }}/></a>`).toEqual(h('a', { x: '1' }, h('b', { y: '2', c: 'bar' }) ));
+		expect(html`<a ...${{ c: 'bar' }}><b ...${{ d: 'baz' }}/></a>`).toEqual(h('a', { c: 'bar' }, h('b', { d: 'baz' }) ));
 	});
 
 	test('mixed spread + static props', () => {
@@ -133,5 +140,24 @@ describe('htm', () => {
 				after
 			</a>
 		`).toEqual(h('a', null, 'before', 'foo', h('b', null), 'bar', 'after'));
+	});
+
+	test('hyphens (-) are allowed in attribute names', () => {
+		expect(html`<a b-c></a>`).toEqual(h('a', { 'b-c': true }));
+	});
+	
+	test('NUL characters are allowed in attribute values', () => {
+		expect(html`<a b="\0"></a>`).toEqual(h('a', { b: '\0' }));
+		expect(html`<a b="\0" c=${'foo'}></a>`).toEqual(h('a', { b: '\0', c: 'foo' }));
+	});
+	
+	test('NUL characters are allowed in text', () => {
+		expect(html`<a>\0</a>`).toEqual(h('a', null, '\0'));
+		expect(html`<a>\0${'foo'}</a>`).toEqual(h('a', null, '\0', 'foo'));
+	});
+	
+	test('cache key should be unique', () => {
+		html`<a b="${'foo'}" />`;
+		expect(html`<a b="\0" />`).toEqual(h('a', { b: '\0' }));
 	});
 });


### PR DESCRIPTION
PR #38 introduces a new custom parser implementing the complete JSX syntax. This pull request adds tests to some corner cases, and suggests fixes for them:

 * JSX allows property names that contain hyphens. This can be fixed by JSON.stringifying the property names.
 * Boolean attributes following non-boolean ones got ignored (e.g. `<a b="1" c />` yielded the result `h('a', { b: '1' })`. This can be fixed by switching to MODE_WHITESPACE when we encounter a whitespace (and after calling `commit()`).
 * `out.replace(/,\(\{(.*?)$/, ',Object.assign({},{$1')` gave unexpected results when there were multiple elements with spreads (because e.g. `"aba".replace(/a.*?$/, "x")` returns `"x"`) as well as attribute values containing the (sub)string `,({`. This can be fixed by separately keeping track of the generated property argument.
 * JSX seems to allow NUL (\u0000) in attribute values and text. As the statics were joined with NULs the parser couldn't tell apart original NULs and template variable placeholders. The joined string was also used as a cache key, with similar ambiguity problems as described in PR #22. This can be fixed by ensuring unique cache keys (similar to #22) and not joining the statics with NULs.