### PR TITLE
Fix multiple spread props in one element

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -67,6 +67,9 @@ function build(statics) {
 					if (!props) props = 'Object.assign({},';
 					else props = 'Object.assign({},' + props + '},';
 				}
+				else {
+					props += '},';
+				}
 				props += field + ',{';
 			}
 			else if (propName) {

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -84,6 +84,10 @@ describe('htm', () => {
 		expect(html`<a ...${{ c: 'bar' }}><b ...${{ d: 'baz' }}/></a>`).toEqual(h('a', { c: 'bar' }, h('b', { d: 'baz' }) ));
 	});
 
+	test('multiple spread props in one element', () => {
+		expect(html`<a ...${{ foo: 'bar' }} ...${{ quux: 'baz' }} />`).toEqual({ tag: 'a', props: { foo: 'bar', quux: 'baz' }, children: [] });
+	});  
+  
 	test('mixed spread + static props', () => {
 		expect(html`<a b ...${{ foo: 'bar' }} />`).toEqual({ tag: 'a', props: { b: true, foo: 'bar' }, children: [] });
 		expect(html`<a b c ...${{ foo: 'bar' }} />`).toEqual({ tag: 'a', props: { b: true, c: true, foo: 'bar' }, children: [] });


### PR DESCRIPTION
This pull request fixes the error introduced in #39, where multiple spread props in one element caused faulty javascript to be generated. Added a test for the case. 