### PR TITLE
Don't use endsWith, produce cleaner output, fix text with a lone quote

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -52,7 +52,7 @@ function build(statics) {
 
 	function commit() {
 		if (!inTag) {
-			if (field || (buffer = buffer.replace(/^\s*\n+\s*|\s*\n+\s*$/g,''))) {
+			if (field || (buffer = buffer.replace(/^\s*\n\s*|\s*\n\s*$/g,''))) {
 				if (hasChildren++) out += ',';
 				out += field || JSON.stringify(buffer);
 			}

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -86,7 +86,7 @@ describe('htm', () => {
 
 	test('multiple spread props in one element', () => {
 		expect(html`<a ...${{ foo: 'bar' }} ...${{ quux: 'baz' }} />`).toEqual({ tag: 'a', props: { foo: 'bar', quux: 'baz' }, children: [] });
-	});  
+	});
   
 	test('mixed spread + static props', () => {
 		expect(html`<a b ...${{ foo: 'bar' }} />`).toEqual({ tag: 'a', props: { b: true, foo: 'bar' }, children: [] });
@@ -107,6 +107,7 @@ describe('htm', () => {
 	test('text child', () => {
 		expect(html`<a>foo</a>`).toEqual({ tag: 'a', props: null, children: ['foo'] });
 		expect(html`<a>foo bar</a>`).toEqual({ tag: 'a', props: null, children: ['foo bar'] });
+		expect(html`<a>foo "<b /></a>`).toEqual({ tag: 'a', props: null, children: ['foo "', { tag: 'b', props: null, children: [] }] });
 	});
 
 	test('dynamic child', () => {


### PR DESCRIPTION
This pull request implements the following fixes and modifications:

 * Get rid of the `.endsWith` usage, making the library more compatible. Generated functions now avoid empty objects, so `<a ...${{ foo: 'bar' }} />` produces `h('a', Object.assign({}, $_h[1]))` instead of `h('a', Object.assign({}, $_h[1], {}))`. This is done by keeping track of the characters needed to close the current props section and the possible current spread. The tracked characters also double as flags, empty string being false.
 * Fix cases where atext part contains a lone single or double quote, such as `<a>foo "<b /></a>`. Add a related test.
 * The whitespace normalization pattern `replace(/^\s*\n+\s*|\s*\n+\s*$/g,'')` was susceptible to [ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS). Alleviated this by changing `\n+` to `\n`.