### PR TITLE
Use JSON.stringify for cache key generation

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -13,8 +13,10 @@
 
 const CACHE = {};
 
+const stringify = JSON.stringify;
+
 export default function html(statics) {
-	const key = statics.length + statics;
+	const key = stringify(statics);
 	const tpl = CACHE[key] || (CACHE[key] = build(statics));
 
 	// eslint-disable-next-line prefer-rest-params
@@ -55,12 +57,12 @@ const build = (statics) => {
 		if (!inTag) {
 			if (field || (buffer = buffer.replace(/^\s*\n\s*|\s*\n\s*$/g,''))) {
 				if (hasChildren++) out += ',';
-				out += field || JSON.stringify(buffer);
+				out += field || stringify(buffer);
 			}
 		}
 		else if (mode === MODE_TAGNAME) {
 			if (hasChildren++) out += ',';
-			out += 'h(' + (field || JSON.stringify(buffer));
+			out += 'h(' + (field || stringify(buffer));
 			mode = MODE_WHITESPACE;
 		}
 		else if (mode === MODE_ATTRIBUTE || (mode === MODE_WHITESPACE && buffer === '...')) {
@@ -77,8 +79,8 @@ const build = (statics) => {
 				if (!props) props += '{';
 				else props += ',' + (propsClose ? '' : '{');
 				propsClose = '}';
-				props += JSON.stringify(propName) + ':';
-				props += field || ((propHasValue || buffer) && JSON.stringify(buffer)) || 'true';
+				props += stringify(propName) + ':';
+				props += field || ((propHasValue || buffer) && stringify(buffer)) || 'true';
 				propName = '';
 			}
 			propHasValue = false;

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -16,7 +16,8 @@ const CACHE = {};
 const stringify = JSON.stringify;
 
 export default function html(statics) {
-	const key = stringify(statics);
+	let key = '.';
+	for (let i=0; i<statics.length; i++) key += statics[i].length + ',' + statics[i];
 	const tpl = CACHE[key] || (CACHE[key] = build(statics));
 
 	// eslint-disable-next-line prefer-rest-params

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -164,5 +164,7 @@ describe('htm', () => {
 	test('cache key should be unique', () => {
 		html`<a b="${'foo'}" />`;
 		expect(html`<a b="\0" />`).toEqual(h('a', { b: '\0' }));
+		expect(html`<a>${''}9aaaaaaaaa${''}</a>`).not.toEqual(html`<a>${''}0${''}aaaaaaaaa${''}</a>`);
+		expect(html`<a>${''}0${''}aaaaaaaa${''}</a>`).not.toEqual(html`<a>${''}.8aaaaaaaa${''}</a>`);
 	});
 });


### PR DESCRIPTION
This pull request modifies the cache key generation to use `JSON.stringify`. With this the cache key is guaranteed to be unique for every unique array of statics, as two different arrays should not have identical JSON serializations.

JSON.stringify is now stored to a module-scoped variable, to cut down the size. This seems to give a (surprising) performance boost in my environment. I suspect this is highly JavaScript engine specific. Benchmarks below.

**Before change:**
`Creation: 36985/s, average: 0.027037810036229928ms`
**After change:**
`Creation: 45726/s, average: 0.02186895613191043ms`

The compressed code size also decreased somewhat.

**Before change:**
```
Build "htm" to dist:
        625 B: htm.mjs.gz
        572 B: htm.mjs.br
        690 B: htm.umd.js.gz
        623 B: htm.umd.js.br
```
**After change:**
```
Build "htm" to dist:
        622 B: htm.mjs.gz
        568 B: htm.mjs.br
        686 B: htm.umd.js.gz
        618 B: htm.umd.js.br
```

Storing `JSON.stringify` in a variable but keeping the cache key generation intact (`statics.length + statics`) seems to yield the same performance, with a slightly larger gzipped code (624B instead of 622B). Uniqueness guarantee for cache keys is also lost.