### PR TITLE
Reorganize the Babel plugin, add support for non-literal template variables

### DIFF
--- a/packages/babel-plugin-htm/index.mjs
+++ b/packages/babel-plugin-htm/index.mjs
@@ -61,39 +61,8 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
 		return t.callExpression(pragma, [tag, props, children]);
 	}
 	
-	function findNextNode(args, start) {
-		for (let i = start; i < args.length; i++) {
-			if (t.isNode(args[i])) {
-				return i;
-			}
-		}
-		return args.length;
-	}
-	
-	function flattenSpread(args) {
-		const flattened = [];
-		for (let i = 0; i < args.length; i++) {
-			if (t.isNode(args[i])) {
-				flattened.push(args[i]);
-			}
-			else {
-				const start = i;
-				const end = findNextNode(args, start + 1);
-				flattened.push(Object.assign(...args.slice(start, end)));
-				i = end - 1;
-			}
-		}
-		return flattened;
-	}
-	
 	function spreadNode(args, state) {
-		args = flattenSpread(args);
-
-		// Case 'Object.assign(x)' can be collapsed to 'x'.
-		if (args.length === 1) {
-			return propsNode(args[0]);
-		}
-		// Case 'Object.assign({}, x)', can be collapsed to 'x'.
+		// 'Object.assign({}, x)', can be collapsed to 'x'.
 		if (args.length === 2 && !t.isNode(args[0]) && Object.keys(args[0]).length === 0) {
 			return propsNode(args[1]);
 		}

--- a/packages/babel-plugin-htm/index.mjs
+++ b/packages/babel-plugin-htm/index.mjs
@@ -6,10 +6,11 @@ import htm from 'htm';
  * @param {string} [options.pragma=h]  JSX/hyperscript pragma.
  * @param {string} [options.tag=html]  The tagged template "tag" function name to process.
  * @param {boolean} [options.monomorphic=false]  Output monomorphic inline objects instead of using String literals.
+ * @param {boolean} [options.useBuiltIns=false]  Use the native Object.assign instead of trying to polyfill it.
  */
 export default function htmBabelPlugin({ types: t }, options = {}) {
 	const pragma = options.pragma===false ? false : dottedIdentifier(options.pragma || 'h');
-  
+	const useBuiltIns = options.useBuiltIns;
 	const inlineVNodes = options.monomorphic || pragma===false;
 
 	function dottedIdentifier(keypath) {
@@ -59,91 +60,91 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
 
 		return t.callExpression(pragma, [tag, props, children]);
 	}
-
-	let isVNode = t.isCallExpression;
-	if (inlineVNodes) {
-		isVNode = node => {
-			if (!t.isObjectExpression(node)) return false;
-			return node.properties[0].value.value!==3;
-		};
-	}
-
-	function childMapper(child, index, children) {
-		// JSX-style whitespace: (@TODO: remove? doesn't match the browser version)
-		if (typeof child==='string' && child.trim().length===0 || child==null) {
-			if (index===0 || index===children.length-1) return null;
-		}
-		if (typeof child==='string' && isVNode(children[index-1]) && isVNode(children[index+1])) {
-			child = child.trim();
-		}
-		if (typeof child==='string') {
-			return stringValue(child);
-		}
-		return child;
-	}
-
-	function h(tag, props) {
-		if (typeof tag==='string') {
-			tag = t.stringLiteral(tag);
-		}
-
-		let propsNode;
-
-		if (t.isObjectExpression(props)) {
-			propsNode = props;
-			for (let i in props) {
-				if (props.hasOwnProperty(i) && props[i] && props[i].type) {
-					for (let j=0; j<props.properties.length; j++) {
-						if (props.properties[j].start > props[i].start) {
-							props.properties.splice(j, 0, t.objectProperty(propertyName(i), props[i]));
-							break;
-						}
-					}
-					delete props[i];
-				}
+	
+	function findNextNode(args, start) {
+		for (let i = start; i < args.length; i++) {
+			if (t.isNode(args[i])) {
+				return i;
 			}
 		}
-		else {
-			propsNode = t.objectExpression(
-				Object.keys(props).map(key => {
-					let value = props[key];
-					if (typeof value==='string') {
-						value = t.stringLiteral(value);
-					}
-					else if (typeof value==='boolean') {
-						value = t.booleanLiteral(value);
-					}
-					else if (typeof value==='number') {
-						value = t.stringLiteral(value + '');
-					}
-					return t.objectProperty(propertyName(key), value);
-				})
-			);
-		}
-
-		// recursive iteration of possibly nested arrays of children.
-		let children = [];
-		if (arguments.length>2) {
-			const stack = [];
-			// eslint-disable-next-line prefer-rest-params
-			for (let i=arguments.length; i-->2; ) stack.push(arguments[i]);
-			while (stack.length) {
-				const child = stack.pop();
-				if (Array.isArray(child)) {
-					for (let i=child.length; i--; ) stack.push(child[i]);
-				}
-				else if (child!=null) {
-					children.push(child);
-				}
+		return args.length;
+	}
+	
+	function flattenSpread(args) {
+		const flattened = [];
+		for (let i = 0; i < args.length; i++) {
+			if (t.isNode(args[i])) {
+				flattened.push(args[i]);
 			}
-			children = children.map(childMapper).filter(Boolean);
+			else {
+				const start = i;
+				const end = findNextNode(args, start + 1);
+				flattened.push(Object.assign(...args.slice(start, end)));
+				i = end - 1;
+			}
 		}
-		children = t.arrayExpression(children);
+		return flattened;
+	}
+	
+	function spreadNode(args, state) {
+		args = flattenSpread(args);
 
-		return createVNode(tag, propsNode, children);
+		// Case 'Object.assign(x)' can be collapsed to 'x'.
+		if (args.length === 1) {
+			return propsNode(args[0]);
+		}
+		// Case 'Object.assign({}, x)', can be collapsed to 'x'.
+		if (args.length === 2 && !t.isNode(args[0]) && Object.keys(args[0]).length === 0) {
+			return propsNode(args[1]);
+		}
+		const helper = useBuiltIns ? dottedIdentifier('Object.assign') : state.addHelper('extends');
+		return t.callExpression(helper, args.map(propsNode));
+	}
+	
+	function propsNode(props) {
+		return t.isNode(props) ? props : t.objectExpression(
+			Object.keys(props).map(key => {
+				let value = props[key];
+				if (typeof value==='string') {
+					value = t.stringLiteral(value);
+				}
+				else if (typeof value==='boolean') {
+					value = t.booleanLiteral(value);
+				}
+				return t.objectProperty(propertyName(key), value);
+			})
+		);
+	}
+
+	function transform({ tag, props, children }, state) {
+		function childMapper(child) {
+			if (typeof child==='string') {
+				return stringValue(child);
+			}
+			return t.isNode(child) ? child : transform(child, state);
+		}
+		const newTag = typeof tag === 'string' ? t.stringLiteral(tag) : tag;
+		const newProps = !Array.isArray(props) ? propsNode(props) : spreadNode(props, state);
+		const newChildren = t.arrayExpression(children.map(childMapper));
+		return createVNode(newTag, newProps, newChildren);
 	}
   
+	function h(tag, props, ...children) {
+		return { tag, props, children };
+	}
+	
 	const html = htm.bind(h);
+	
+	function treeify(statics, expr) {
+		const assign = Object.assign;
+		try {
+			Object.assign = function(...objs) {	return objs; };
+			return html(statics, ...expr);
+		}
+		finally {
+			Object.assign = assign;
+		}
+	}
 
 	// The tagged template tag function name we're looking for.
 	// This is static because it's generally assigned via htm.bind(h),
@@ -152,12 +153,14 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
 	return {
 		name: 'htm',
 		visitor: {
-			TaggedTemplateExpression(path) {
+			TaggedTemplateExpression(path, state) {
 				const tag = path.node.tag.name;
 				if (htmlName[0]==='/' ? patternStringToRegExp(htmlName).test(tag) : tag === htmlName) {
 					const statics = path.node.quasi.quasis.map(e => e.value.raw);
 					const expr = path.node.quasi.expressions;
-					path.replaceWith(html(statics, ...expr));
+
+					const tree = treeify(statics, expr);
+					path.replaceWith(transform(tree, state));
 				}
 			}
 		}

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -71,7 +71,7 @@ const build = (statics) => {
 				if (!spreadClose) {
 					spreadClose = ')';
 					if (!props) props = 'Object.assign({}';
-					else props = 'Object.assign({},' + props;
+					else props = 'Object.assign(' + props;
 				}
 				props += propsClose + ',' + field;
 				propsClose = '';

--- a/test/babel.test.mjs
+++ b/test/babel.test.mjs
@@ -56,7 +56,7 @@ describe('htm/babel', () => {
 		).toBe(`h("a",foo,[]);`);
 	});
 	
-	test('spread a two variables', () => {
+	test('spread two variables', () => {
 		expect(
 			transform('html`<a ...${foo} ...${bar}></a>`;', {
 				babelrc: false,
@@ -68,6 +68,34 @@ describe('htm/babel', () => {
 				]
 			}).code
 		).toBe(`h("a",Object.assign({},foo,bar),[]);`);
+	});
+	
+	test('property followed by a spread', () => {
+		expect(
+			transform('html`<a b="1" ...${foo}></a>`;', {
+				babelrc: false,
+				compact: true,
+				plugins: [
+					[htmBabelPlugin, {
+						useBuiltIns: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",Object.assign({b:"1"},foo),[]);`);
+	});
+	
+	test('spread followed by a property', () => {
+		expect(
+			transform('html`<a ...${foo} b="1"></a>`;', {
+				babelrc: false,
+				compact: true,
+				plugins: [
+					[htmBabelPlugin, {
+						useBuiltIns: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",Object.assign({},foo,{b:"1"}),[]);`);
 	});
 	
 	test('mix-and-match spreads', () => {
@@ -83,7 +111,7 @@ describe('htm/babel', () => {
 			}).code
 		).toBe(`h("a",Object.assign({b:"1"},foo,{c:2},{d:3}),[]);`);
 	});
-
+	
 	test('inline vnode transformation: (pragma:false)', () => {
 		expect(
 			transform('var name="world",vnode=html`<div id=hello>hello, ${name}</div>`;', {

--- a/test/babel.test.mjs
+++ b/test/babel.test.mjs
@@ -36,10 +36,52 @@ describe('htm/babel', () => {
 				babelrc: false,
 				compact: true,
 				plugins: [
+					[htmBabelPlugin, {
+						useBuiltIns: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",Object.assign({b:2},{c:3}),["d: ",4]);`);
+	});
+	
+	test('spread a single variable', () => {
+		expect(
+			transform('html`<a ...${foo}></a>`;', {
+				babelrc: false,
+				compact: true,
+				plugins: [
 					htmBabelPlugin
 				]
 			}).code
-		).toBe(`h("a",{b:2,c:3},["d: ",4]);`);
+		).toBe(`h("a",foo,[]);`);
+	});
+	
+	test('spread a two variables', () => {
+		expect(
+			transform('html`<a ...${foo} ...${bar}></a>`;', {
+				babelrc: false,
+				compact: true,
+				plugins: [
+					[htmBabelPlugin, {
+						useBuiltIns: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",Object.assign({},foo,bar),[]);`);
+	});
+	
+	test('mix-and-match spreads', () => {
+		expect(
+			transform('html`<a b="1" ...${foo} c=${2} ...${{d:3}}></a>`;', {
+				babelrc: false,
+				compact: true,
+				plugins: [
+					[htmBabelPlugin, {
+						useBuiltIns: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",Object.assign({b:"1"},foo,{c:2},{d:3}),[]);`);
 	});
 
 	test('inline vnode transformation: (pragma:false)', () => {

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -168,4 +168,10 @@ describe('htm', () => {
 		expect(html`<a>${''}9aaaaaaaaa${''}</a>`).not.toEqual(html`<a>${''}0${''}aaaaaaaaa${''}</a>`);
 		expect(html`<a>${''}0${''}aaaaaaaa${''}</a>`).not.toEqual(html`<a>${''}.8aaaaaaaa${''}</a>`);
 	});
+	
+	test('do not mutate spread variables', () => {
+		const obj = {};
+		html`<a ...${obj} b="1" />`;
+		expect(obj).toEqual({});
+	});
 });


### PR DESCRIPTION
This pull request reorganizes the Babel plugin and adds tests, with the following steps:
 1. In `treeify` the template is evaluated and converted to a object tree with `h(tag, props, ...children) { return { tag, props, children }; }`. `h` is intentionally as simple as possible, because there's a not-so-pretty trick: `Object.assign` is temporarily replaced with our own function that doesn't smush its arguments together, but just returns them as an array. This allows us to simplify props handling and do some optimizations to the output.
 2. Return `Object.assign` back to the value it was before evaluating the template.
 3. The resulting tree is transformed recursively, top-down in `transform`.

In `transform` the `props` argument is now either an array (from the `Object.assign` trick), `null` or an object. If it's an array then it's further processed: sometimes we can get rid of the spread altogether (e.g. `Object.assign(foo)` can just become `foo`). This allows us also to support non-literal template variables in spreads, e.g. `<a ...${foo}>` now gets transformed to 'h("a",foo,[])`.

When we actually need a spread output, like in `<a b=1 ...${foo}>`, the output follows (somewhat) what [@babel/preset-react](https://babeljs.io/docs/en/babel-preset-react) does. There's now a new setting `useBuiltIns` that is `false` by default that has the same meaning as in @babel/preset-react. When the flag is true the output for `<a b=1 ...${foo}>` is `h("a",Object.assign({b:"1"},foo),[])`, and if the flag is false then Babel's `extends`-helper is included in the output.

`childMapper` is now recursive and a bit simpler, as `htm` itself does JSX-style whitespace normalization.