### PR TITLE
Use $[] instead of $_h[] inside the generated functions

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -100,7 +100,7 @@ const build = (statics) => {
 	for (let i=0; i<statics.length; i++) {
 		if (i > 0) {
 			if (!inTag) commit();
-			field = `$_h[${i}]`;
+			field = `$[${i}]`;
 			commit();
 		}
 		
@@ -180,5 +180,5 @@ const build = (statics) => {
 		}
 	}
 	commit();
-	return Function('h', '$_h', out);
+	return Function('h', '$', out);
 };


### PR DESCRIPTION
Because the function name `$_h` is not a placeholder in the new custom parser it can be replaced with something shorter - like `$`. This shaves off few bytes from the code size (584 B for htm.mjs.br instead of 588 B).