### PR TITLE
Size optimizations for src/index.mjs

### DIFF
--- a/packages/babel-plugin-htm/index.mjs
+++ b/packages/babel-plugin-htm/index.mjs
@@ -147,7 +147,10 @@ export default function htmBabelPlugin({ types: t }, options = {}) {
 					const expr = path.node.quasi.expressions;
 
 					const tree = treeify(statics, expr);
-					path.replaceWith(transform(tree, state));
+					const node = !Array.isArray(tree)
+						? transform(tree, state)
+						: t.arrayExpression(tree.map(root => transform(root, state)));
+					path.replaceWith(node);
 				}
 			}
 		}

--- a/src/build.mjs
+++ b/src/build.mjs
@@ -2,9 +2,9 @@ const stringify = JSON.stringify;
 
 const MODE_SKIP = 0;
 const MODE_TEXT = 1;
-const MODE_WHITESPACE = 3;
-const MODE_TAGNAME = 4;
-const MODE_ATTRIBUTE = 5;
+const MODE_WHITESPACE = 2;
+const MODE_TAGNAME = 3;
+const MODE_ATTRIBUTE = 4;
 
 /** Create a template function given strings from a tagged template. */
 export const build = (statics) => {
@@ -19,40 +19,34 @@ export const build = (statics) => {
 	let spreadClose = '';
 	let quote = '';
 	let depth = 0;
-	let fallbackPropValue = true;
-	let char, propName, idx;
-
+	let char, propName;
+	
 	const commit = field => {
-		if (mode === MODE_TEXT) {
-			if (field || (buffer = buffer.replace(/^\s*\n\s*|\s*\n\s*$/g,''))) {
-				out += childClose + (field || stringify(buffer));
-				childClose = ',';
-			}
+		if (mode === MODE_TEXT && (field || (buffer = buffer.replace(/^\s*\n\s*|\s*\n\s*$/g,'')))) {
+			out += childClose + (field || stringify(buffer));
+			childClose = ',';
 		}
-		else if (mode === MODE_TAGNAME) {
+		else if (mode === MODE_TAGNAME && (field || buffer)) {
 			out += childClose + 'h(' + (field || stringify(buffer));
 			childClose = ',';
 			mode = MODE_WHITESPACE;
 		}
-		else if (mode === MODE_WHITESPACE && buffer === '...') {
+		else if (mode === MODE_WHITESPACE && buffer === '...' && field) {
 			if (!spreadClose) {
 				props = 'Object.assign(' + (props || '{}');
 			}
-			props += propsClose + ',' + (field || '');
+			props += propsClose + ',' + field;
 			propsClose = '';
 			spreadClose = ')';
 		}
-		else if (mode === MODE_ATTRIBUTE || mode === MODE_WHITESPACE) {
-			if (mode === MODE_WHITESPACE) {
-				propName = buffer;
-				buffer = '';
-			}
-			if (propName) {
-				props += (props ? ',' + (propsClose ? '' : '{') : '{') + stringify(propName) + ':' + (field || stringify(buffer || fallbackPropValue));
-				propsClose = '}';
-				propName = '';
-			}
-			fallbackPropValue = true;
+		else if (mode === MODE_WHITESPACE && buffer && !field) {
+			props += (props ? ',' + (propsClose ? '' : '{') : '{') + stringify(buffer) + ':true';
+			propsClose = '}';
+		}
+		else if (mode === MODE_ATTRIBUTE && propName) {
+			props += (props ? ',' + (propsClose ? '' : '{') : '{') + stringify(propName) + ':' + (field || stringify(buffer));
+			propsClose = '}';
+			propName = '';
 		}
 		buffer = '';
 	};
@@ -68,55 +62,62 @@ export const build = (statics) => {
 		for (let j=0; j<statics[i].length; j++) {
 			char = statics[i][j];
 
-			if (mode === MODE_TEXT && char === '<') {
-				// commit buffer
-				commit();
-				tagClose = spreadClose = propsClose = props = '';
-				if (!(depth++) && out && !outClose) {
-					out = '[' + out;
-					outClose = ']';
-				}
-				mode = MODE_TAGNAME;
-			}
-			else if (mode !== MODE_TEXT && (char === quote || !quote) && (idx = '\'">=/\t\n\r '.indexOf(char)) >= 0) {
-				if (idx < 2) {
-					// char === '"' || char === "'"
-					quote = quote ? '' : char;
-				}
-				else if (idx === 2) {
-					// char === '>'
+			if (mode === MODE_TEXT) {
+				if (char === '<') {
+					// commit buffer
 					commit();
-					if (mode !== MODE_SKIP) {
-						out += ',' + (props + propsClose + spreadClose || null);
+					tagClose = spreadClose = propsClose = props = '';
+					if (!(depth++) && out && !outClose) {
+						out = '[' + out;
+						outClose = ']';
 					}
-					out += tagClose;
-					mode = MODE_TEXT;
-					commit();
-				}
-				else if (idx === 3) {
-					// char === '='
-					mode = MODE_ATTRIBUTE;
-					propName = buffer;
-					buffer = fallbackPropValue = '';
-				}
-				else if (idx === 4) {
-					// char === '/'
-					if (!tagClose) {
-						tagClose = ')';
-						// </foo>
-						if (mode === MODE_TAGNAME && !buffer.trim()) {
-							buffer = '';
-							mode = MODE_SKIP;
-						}
-						depth--;
-					}
+					mode = MODE_TAGNAME;
 				}
 				else {
-					// char is a whitespace
-					// <a disabled>
-					commit();
-					mode = MODE_WHITESPACE;
+					buffer += char;
 				}
+			}
+			else if (quote) {
+				if (char === quote) {
+					quote = '';
+				}
+				else {
+					buffer += char;
+				}
+			}
+			else if (char === '"' || char === "'") {
+				quote = char;
+			}
+			else if (char === '>') {
+				commit();
+				if (mode) {
+					out += ',' + (props + propsClose + spreadClose || null);
+				}
+				out += tagClose;
+				mode = MODE_TEXT;
+			}
+			else if (tagClose) {
+				// Skip the rest of the tag
+			}
+			else if (char === '=') {
+				mode = MODE_ATTRIBUTE;
+				propName = buffer;
+				buffer = '';
+			}
+			else if (char === '/') {
+				// </foo>
+				commit();
+				if (mode === MODE_TAGNAME) {
+					mode = MODE_SKIP;
+					buffer = '';
+				}
+				depth--;
+				tagClose = ')';
+			}
+			else if (char === ' ' || char === '\t' || char === '\n' || char === '\r') {
+				// <a disabled>
+				commit();
+				mode = MODE_WHITESPACE;
 			}
 			else {
 				buffer += char;

--- a/src/build.mjs
+++ b/src/build.mjs
@@ -1,0 +1,128 @@
+const stringify = JSON.stringify;
+
+const MODE_SKIP = 0;
+const MODE_TEXT = 1;
+const MODE_WHITESPACE = 3;
+const MODE_TAGNAME = 4;
+const MODE_ATTRIBUTE = 5;
+
+/** Create a template function given strings from a tagged template. */
+export const build = (statics) => {
+	let mode = MODE_TEXT;
+	let out = '';
+	let outClose = '';
+	let buffer = '';
+	let tagClose = '';
+	let childClose = '';
+	let props = '';
+	let propsClose = '';
+	let spreadClose = '';
+	let quote = '';
+	let depth = 0;
+	let fallbackPropValue = true;
+	let char, propName, idx;
+
+	const commit = field => {
+		if (mode === MODE_TEXT) {
+			if (field || (buffer = buffer.replace(/^\s*\n\s*|\s*\n\s*$/g,''))) {
+				out += childClose + (field || stringify(buffer));
+				childClose = ',';
+			}
+		}
+		else if (mode === MODE_TAGNAME) {
+			out += childClose + 'h(' + (field || stringify(buffer));
+			childClose = ',';
+			mode = MODE_WHITESPACE;
+		}
+		else if (mode === MODE_WHITESPACE && buffer === '...') {
+			if (!spreadClose) {
+				props = 'Object.assign(' + (props || '{}');
+			}
+			props += propsClose + ',' + (field || '');
+			propsClose = '';
+			spreadClose = ')';
+		}
+		else if (mode === MODE_ATTRIBUTE || mode === MODE_WHITESPACE) {
+			if (mode === MODE_WHITESPACE) {
+				propName = buffer;
+				buffer = '';
+			}
+			if (propName) {
+				props += (props ? ',' + (propsClose ? '' : '{') : '{') + stringify(propName) + ':' + (field || stringify(buffer || fallbackPropValue));
+				propsClose = '}';
+				propName = '';
+			}
+			fallbackPropValue = true;
+		}
+		buffer = '';
+	};
+
+	for (let i=0; i<statics.length; i++) {
+		if (i) {
+			if (mode === MODE_TEXT) {
+				commit();
+			}
+			commit(`$[${i}]`);
+		}
+		
+		for (let j=0; j<statics[i].length; j++) {
+			char = statics[i][j];
+
+			if (mode === MODE_TEXT && char === '<') {
+				// commit buffer
+				commit();
+				tagClose = spreadClose = propsClose = props = '';
+				if (!(depth++) && out && !outClose) {
+					out = '[' + out;
+					outClose = ']';
+				}
+				mode = MODE_TAGNAME;
+			}
+			else if (mode !== MODE_TEXT && (char === quote || !quote) && (idx = '\'">=/\t\n\r '.indexOf(char)) >= 0) {
+				if (idx < 2) {
+					// char === '"' || char === "'"
+					quote = quote ? '' : char;
+				}
+				else if (idx === 2) {
+					// char === '>'
+					commit();
+					if (mode !== MODE_SKIP) {
+						out += ',' + (props + propsClose + spreadClose || null);
+					}
+					out += tagClose;
+					mode = MODE_TEXT;
+					commit();
+				}
+				else if (idx === 3) {
+					// char === '='
+					mode = MODE_ATTRIBUTE;
+					propName = buffer;
+					buffer = fallbackPropValue = '';
+				}
+				else if (idx === 4) {
+					// char === '/'
+					if (!tagClose) {
+						tagClose = ')';
+						// </foo>
+						if (mode === MODE_TAGNAME && !buffer.trim()) {
+							buffer = '';
+							mode = MODE_SKIP;
+						}
+						depth--;
+					}
+				}
+				else {
+					// char is a whitespace
+					// <a disabled>
+					commit();
+					mode = MODE_WHITESPACE;
+				}
+			}
+			else {
+				buffer += char;
+			}
+		}
+	}
+	commit();
+	return Function('h', '$', 'return ' + out + outClose);
+};

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -47,7 +47,7 @@ const build = (statics) => {
 	let out = 'return ';
 	let buffer = '';
 	let field = '';
-	let hasChildren = 0;
+	let childClose = '';
 	let props = '';
 	let propsClose = '';
 	let spreadClose = '';
@@ -57,13 +57,13 @@ const build = (statics) => {
 	const commit = () => {
 		if (mode === MODE_TEXT) {
 			if (field || (buffer = buffer.replace(/^\s*\n\s*|\s*\n\s*$/g,''))) {
-				if (hasChildren++) out += ',';
-				out += field || stringify(buffer);
+				out += childClose + (field || stringify(buffer));
+				childClose = ',';
 			}
 		}
 		else if (mode === MODE_TAGNAME) {
-			if (hasChildren++) out += ',';
-			out += 'h(' + (field || stringify(buffer));
+			out += childClose + 'h(' + (field || stringify(buffer));
+			childClose = ',';
 			mode = MODE_WHITESPACE;
 		}
 		else if (mode === MODE_ATTRIBUTE || (mode === MODE_WHITESPACE && buffer === '...')) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -46,12 +46,13 @@ const build = (statics) => {
 	let mode = MODE_TEXT;
 	let out = 'return ';
 	let buffer = '';
+	let tagClose = '';
 	let childClose = '';
 	let props = '';
 	let propsClose = '';
 	let spreadClose = '';
 	let quote = 0;
-	let slash, charCode, propName, propHasValue;
+	let charCode, propName, propHasValue;
 
 	const commit = field => {
 		if (mode === MODE_TEXT) {
@@ -108,8 +109,8 @@ const build = (statics) => {
 				if (charCode === TAG_START) {
 					// commit buffer
 					commit();
-					spreadClose = propsClose = props = '';
-					slash = propHasValue = false;
+					tagClose = spreadClose = propsClose = props = '';
+					propHasValue = false;
 					mode = MODE_TAGNAME;
 					continue;
 				}
@@ -138,10 +139,7 @@ const build = (statics) => {
 									out += ',' + props + propsClose + spreadClose;
 								}
 							}
-							if (slash) {
-								out += ')';
-							}
-							props = '';
+							out += tagClose;
 							mode = MODE_TEXT;
 							continue;
 						case EQUALS:
@@ -151,8 +149,8 @@ const build = (statics) => {
 							buffer = '';
 							continue;
 						case SLASH:
-							if (!slash) {
-								slash = true;
+							if (!tagClose) {
+								tagClose = ')';
 								// </foo>
 								if (mode === MODE_TAGNAME && !buffer.trim()) {
 									buffer = '';

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -11,9 +11,9 @@
  * limitations under the License.
  */
 
+import { build } from './build.mjs';
+ 
 const CACHE = {};
-
-const stringify = JSON.stringify;
 
 export default function html(statics) {
 	let key = '.';
@@ -23,123 +23,3 @@ export default function html(statics) {
 	// eslint-disable-next-line prefer-rest-params
 	return tpl(this, arguments);
 }
-
-const MODE_SKIP = 0;
-const MODE_TEXT = 1;
-const MODE_WHITESPACE = 3;
-const MODE_TAGNAME = 4;
-const MODE_ATTRIBUTE = 5;
-
-/** Create a template function given strings from a tagged template. */
-const build = (statics) => {
-	let mode = MODE_TEXT;
-	let out = 'return ';
-	let buffer = '';
-	let tagClose = '';
-	let childClose = '';
-	let props = '';
-	let propsClose = '';
-	let spreadClose = '';
-	let quote = '';
-	let fallbackPropValue = true;
-	let char, propName, idx;
-
-	const commit = field => {
-		if (mode === MODE_TEXT) {
-			if (field || (buffer = buffer.replace(/^\s*\n\s*|\s*\n\s*$/g,''))) {
-				out += childClose + (field || stringify(buffer));
-				childClose = ',';
-			}
-		}
-		else if (mode === MODE_TAGNAME) {
-			out += childClose + 'h(' + (field || stringify(buffer));
-			childClose = ',';
-			mode = MODE_WHITESPACE;
-		}
-		else if (mode === MODE_WHITESPACE && buffer === '...') {
-			if (!spreadClose) {
-				props = 'Object.assign(' + (props || '{}');
-			}
-			props += propsClose + ',' + (field || '');
-			propsClose = '';
-			spreadClose = ')';
-		}
-		else if (mode === MODE_ATTRIBUTE || mode === MODE_WHITESPACE) {
-			if (mode === MODE_WHITESPACE) {
-				propName = buffer;
-				buffer = '';
-			}
-			if (propName) {
-				props += (props ? ',' + (propsClose ? '' : '{') : '{') + stringify(propName) + ':' + (field || stringify(buffer || fallbackPropValue));
-				propsClose = '}';
-				propName = '';
-			}
-			fallbackPropValue = true;
-		}
-		buffer = '';
-	};
-
-	for (let i=0; i<statics.length; i++) {
-		if (i) {
-			if (mode === MODE_TEXT) {
-				commit();
-			}
-			commit(`$[${i}]`);
-		}
-		
-		for (let j=0; j<statics[i].length; j++) {
-			char = statics[i][j];
-
-			if (mode === MODE_TEXT && char === '<') {
-				// commit buffer
-				commit();
-				tagClose = spreadClose = propsClose = props = '';
-				mode = MODE_TAGNAME;
-			}
-			else if (mode !== MODE_TEXT && (char === quote || !quote) && (idx = '\'">=/\t\n\r '.indexOf(char)) >= 0) {
-				if (idx < 2) {
-					// char === '"' || char === "'"
-					quote = quote ? '' : char;
-				}
-				else if (idx === 2) {
-					// char === '>'
-					commit();
-					if (mode !== MODE_SKIP) {
-						out += ',' + (props + propsClose + spreadClose || null);
-					}
-					out += tagClose;
-					mode = MODE_TEXT;
-					commit();
-				}
-				else if (idx === 3) {
-					// char === '='
-					mode = MODE_ATTRIBUTE;
-					propName = buffer;
-					buffer = fallbackPropValue = '';
-				}
-				else if (idx === 4) {
-					// char === '/'
-					if (!tagClose) {
-						tagClose = ')';
-						// </foo>
-						if (mode === MODE_TAGNAME && !buffer.trim()) {
-							buffer = '';
-							mode = MODE_SKIP;
-						}
-					}
-				}
-				else {
-					// char is a whitespace
-					// <a disabled>
-					commit();
-					mode = MODE_WHITESPACE;
-				}
-			}
-			else {
-				buffer += char;
-			}
-		}
-	}
-	commit();
-	return Function('h', '$', out);
-};

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -98,7 +98,7 @@ const build = (statics) => {
 	};
 
 	for (let i=0; i<statics.length; i++) {
-		if (i > 0) {
+		if (i) {
 			if (mode === MODE_TEXT) commit();
 			commit(`$[${i}]`);
 		}

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -46,7 +46,6 @@ const build = (statics) => {
 	let mode = MODE_TEXT;
 	let out = 'return ';
 	let buffer = '';
-	let field = '';
 	let childClose = '';
 	let props = '';
 	let propsClose = '';
@@ -54,7 +53,7 @@ const build = (statics) => {
 	let quote = 0;
 	let slash, charCode, propName, propHasValue;
 
-	const commit = () => {
+	const commit = field => {
 		if (mode === MODE_TEXT) {
 			if (field || (buffer = buffer.replace(/^\s*\n\s*|\s*\n\s*$/g,''))) {
 				out += childClose + (field || stringify(buffer));
@@ -71,7 +70,7 @@ const build = (statics) => {
 				if (!spreadClose) {
 					props = 'Object.assign(' + (props || '{}');
 				}
-				props += propsClose + ',' + field;
+				props += propsClose + ',' + (field || '');
 				propsClose = '';
 				spreadClose = ')';
 			}
@@ -89,18 +88,17 @@ const build = (statics) => {
 			mode = MODE_ATTRIBUTE;
 			// we're in an attribute name
 			propName = buffer;
-			buffer = field = '';
+			buffer = '';
 			commit();
 			mode = MODE_WHITESPACE;
 		}
-		buffer = field = '';
+		buffer = '';
 	};
 
 	for (let i=0; i<statics.length; i++) {
 		if (i > 0) {
 			if (mode === MODE_TEXT) commit();
-			field = `$[${i}]`;
-			commit();
+			commit(`$[${i}]`);
 		}
 		
 		for (let j=0; j<statics[i].length; j++) {
@@ -157,7 +155,7 @@ const build = (statics) => {
 								slash = true;
 								// </foo>
 								if (mode === MODE_TAGNAME && !buffer.trim()) {
-									buffer = field = '';
+									buffer = '';
 									mode = MODE_SKIP;
 								}
 							}

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -35,15 +35,15 @@ const RETURN = 13;
 const SPACE = 32;
 const SLASH = 47;
 
-const MODE_WHITESPACE = 0;
-const MODE_TEXT = 1;
+const MODE_TEXT = 0;
+const MODE_WHITESPACE = 1;
 const MODE_TAGNAME = 9;
 const MODE_ATTRIBUTE = 13;
 const MODE_SKIP = 47;
 
 /** Create a template function given strings from a tagged template. */
 const build = (statics) => {
-	let mode = MODE_WHITESPACE;
+	let mode = MODE_TEXT;
 	let out = 'return ';
 	let buffer = '';
 	let field = '';
@@ -52,10 +52,10 @@ const build = (statics) => {
 	let propsClose = '';
 	let spreadClose = '';
 	let quote = 0;
-	let slash, charCode, inTag, propName, propHasValue;
+	let slash, charCode, propName, propHasValue;
 
 	const commit = () => {
-		if (!inTag) {
+		if (mode === MODE_TEXT) {
 			if (field || (buffer = buffer.replace(/^\s*\n\s*|\s*\n\s*$/g,''))) {
 				if (hasChildren++) out += ',';
 				out += field || stringify(buffer);
@@ -99,7 +99,7 @@ const build = (statics) => {
 
 	for (let i=0; i<statics.length; i++) {
 		if (i > 0) {
-			if (!inTag) commit();
+			if (mode === MODE_TEXT) commit();
 			field = `$[${i}]`;
 			commit();
 		}
@@ -107,11 +107,10 @@ const build = (statics) => {
 		for (let j=0; j<statics[i].length; j++) {
 			charCode = statics[i].charCodeAt(j);
 
-			if (!inTag) {
+			if (mode === MODE_TEXT) {
 				if (charCode === TAG_START) {
 					// commit buffer
 					commit();
-					inTag = 1;
 					spreadClose = propsClose = props = '';
 					slash = propHasValue = false;
 					mode = MODE_TAGNAME;
@@ -145,7 +144,6 @@ const build = (statics) => {
 							if (slash) {
 								out += ')';
 							}
-							inTag = 0;
 							props = '';
 							mode = MODE_TEXT;
 							continue;

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -69,12 +69,11 @@ const build = (statics) => {
 		else if (mode === MODE_ATTRIBUTE || (mode === MODE_WHITESPACE && buffer === '...')) {
 			if (mode === MODE_WHITESPACE) {
 				if (!spreadClose) {
-					spreadClose = ')';
-					if (!props) props = 'Object.assign({}';
-					else props = 'Object.assign(' + props;
+					props = 'Object.assign(' + (props || '{}');
 				}
 				props += propsClose + ',' + field;
 				propsClose = '';
+				spreadClose = ')';
 			}
 			else if (propName) {
 				if (!props) props += '{';

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -80,16 +80,9 @@ const build = (statics) => {
 				propName = buffer;
 				buffer = '';
 			}
-			
 			if (propName) {
-				if (!props) {
-					props += '{';
-				}
-				else {
-					props += ',' + (propsClose ? '' : '{');
-				}
+				props += (props ? ',' + (propsClose ? '' : '{') : '{') + stringify(propName) + ':' + (field || stringify(buffer || fallbackPropValue));
 				propsClose = '}';
-				props += stringify(propName) + ':' + (field || stringify(buffer || fallbackPropValue));
 				propName = '';
 			}
 			fallbackPropValue = true;
@@ -132,12 +125,7 @@ const build = (statics) => {
 						case TAG_END:
 							commit();
 							if (mode !== MODE_SKIP) {
-								if (!props) {
-									out += ',null';
-								}
-								else {
-									out += ',' + props + propsClose + spreadClose;
-								}
+								out += ',' + (props + propsClose + spreadClose || null);
 							}
 							out += tagClose;
 							mode = MODE_TEXT;

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -27,6 +27,14 @@ describe('htm', () => {
 		expect(html`<span />`).toEqual({ tag: 'span', props: null, children: [] });
 	});
 
+	test('multiple root elements', () => {
+		expect(html`<a /><b></b><c><//>`).toEqual([
+			{ tag: 'a', props: null, children: [] },
+			{ tag: 'b', props: null, children: [] },
+			{ tag: 'c', props: null, children: [] }
+		]);
+	});
+	
 	test('single dynamic tag name', () => {
 		expect(html`<${'foo'} />`).toEqual({ tag: 'foo', props: null, children: [] });
 		function Foo () {}


### PR DESCRIPTION
This pull request optimizes the size of the minified & compressed library. Mostly it's using the trick is collapsing a state flag and a appendable string together, like `propsClose` previously.

 * Remove `inTag` by using the `mode` variable for it instead (we're not in a tag if `mode === MODE_TEXT`).
 * Spread code repeated `Object.assign`.
 * Keep track if child and tag states with `childClose` and `tagClose`.
 * Replace `propHasValue` with `fallbackPropValue` that can be stringified instead when `buffer` is empty.

These changes together have the following effect on the library size:

**Before change:**
```
Build "htm" to dist:
        649 B: htm.mjs.gz
        596 B: htm.mjs.br
        714 B: htm.umd.js.gz
        645 B: htm.umd.js.br
```

**After change:**
```
Build "htm" to dist:
        605 B: htm.mjs.gz
        546 B: htm.mjs.br
        670 B: htm.umd.js.gz
        599 B: htm.umd.js.br
```