### PR TITLE
Add missing Component export from Preact integration

### DIFF
--- a/src/integrations/preact/index.d.ts
+++ b/src/integrations/preact/index.d.ts
@@ -1,4 +1,4 @@
-import { h, VNode } from 'preact';
+import { h, VNode, Component } from 'preact';
 declare function render(tree: VNode, parent: HTMLElement): void;
 declare const html: (strings: TemplateStringsArray, ...values: any[]) => VNode;
-export { h, html, render };
+export { h, html, render, Component };


### PR DESCRIPTION
The TypeScript definition misses a `Component` export from preact. This PR imports the Component class from "preact" and exports it in the definition file.