### PR TITLE
Use WeakMap for caching

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -11,14 +11,15 @@
  * limitations under the License.
  */
 
-const CACHE = {};
+const CACHE = new WeakMap();
 
 const stringify = JSON.stringify;
 
 export default function html(statics) {
-	let key = '.';
-	for (let i=0; i<statics.length; i++) key += statics[i].length + ',' + statics[i];
-	const tpl = CACHE[key] || (CACHE[key] = build(statics));
+	let tpl = CACHE.get(statics);
+	if (!tpl) {
+		CACHE.set(statics, tpl = build(statics));
+	}
 
 	// eslint-disable-next-line prefer-rest-params
 	return tpl(this, arguments);

--- a/test/perf.test.mjs
+++ b/test/perf.test.mjs
@@ -29,7 +29,7 @@ describe('performance', () => {
 			return html(
 				statics.concat(['count:', count]),
 				`id${count}`,
-				html(['<li data-id="','">', '</li>'], 'i'+count, 'some text #'+count),
+				html`<li data-id="${'i'+count}">${'some text #'+count}</li>`,
 				Foo, Foo, Foo
 			);
 		}
@@ -50,18 +50,18 @@ describe('performance', () => {
 	test('usage', () => {
 		const results = [];
 		const Foo = ({ name }) => html`<div class="foo">${name}</div>`;
-		const statics = [
-			'\n<div id=app data-loading="true">\n\t<h1>Hello World</h1>\n\t<ul class="items" id=', '>\n\t',
-			'\n\t</ul>\n\t\n\t<', ' name="foo" />\n\t<', ' name="other">content</', '>\n\n</div>'
-		];
 		let count = 0;
 		function go(count) {
-			return html(
-				statics,
-				`id${count}`,
-				html(['<li data-id="','">', '</li>'], 'i'+count, 'some text #'+count),
-				Foo, Foo, Foo
-			);
+			return html`
+				<div id=app data-loading="true">
+					<h1>Hello World</h1>
+					<ul class="items" id=${'id' + count}>
+						${html`<li data-id="${'i' + count}">${'some text #' + count}</li>`}
+					</ul>
+					<${Foo} name="foo" />
+					<${Foo} name="other">content<//>
+				</div>
+			`;
 		}
 		let now = performance.now();
 		const start = now;


### PR DESCRIPTION
In a Twitter conversation https://twitter.com/webreflection raised the point that template literal statics are cached. They're cached [by call site](https://github.com/tc39/ecma262/pull/890), which makes them ideal for this purpose. Combining this with WeakMaps (which are also [supported in IE 11](https://kangax.github.io/compat-table/es6/#ie11)) allows fast caching while avoiding cache retention of unnecessary templates.

This pull request first modifies the benchmarks to use tagged template literals whenever possible to match the most common usage pattern. After that it switches to WeakMap based caching.

The code size goes down, and the "usage" benchmark numbers improve:

**Before change**

```
Build "htm" to dist:
        649 B: htm.mjs.gz
        596 B: htm.mjs.br
        714 B: htm.umd.js.gz
        645 B: htm.umd.js.br

console.log test/perf.test.mjs:45
  Creation: 39,626/s, average: 25µs
console.log test/perf.test.mjs:75
  Usage: 243,791/s, average: 4µs
```

**After change**

```
Build "htm" to dist:
        640 B: htm.mjs.gz
        592 B: htm.mjs.br
        706 B: htm.umd.js.gz
        637 B: htm.umd.js.br

console.log test/perf.test.mjs:45
  Creation: 46,867/s, average: 21µs
console.log test/perf.test.mjs:75
  Usage: 363,535/s, average: 2µs
```

When I ran the benchmarks without Jest the difference in the "usage" benchmark was even more pronounced:

**Before change**

```
Usage: 549,356/s, average: 1µs
```

**After change**
```
Usage: 1,542,630/s, average: 0µs
```

In the thread there was a suggestion to fall back to Map if WeakMaps aren't present. I didn't implement that, because all platforms (with the exception es6-shim) [support WeakMap if they support Map](https://kangax.github.io/compat-table/es6/).

The drawback in this approach is that the library now requires WeakMap. However, it appears that platforms that don't support WeakMap natively also don't support tagged templates natively.