### PR TITLE
Add import option to babel-plugin-transform-jsx-to-htm

### DIFF
--- a/test/babel-transform-jsx.test.mjs
+++ b/test/babel-transform-jsx.test.mjs
@@ -5,7 +5,7 @@ function compile(code, { plugins = [], ...options } = {}) {
 	return transform(code, {
 		babelrc: false,
 		configFile: false,
-		sourceType: 'script',
+		sourceType: 'module',
 		plugins: [
 			...plugins,
 			[transformJsxToHtmPlugin, options]
@@ -14,6 +14,50 @@ function compile(code, { plugins = [], ...options } = {}) {
 }
 
 describe('babel-plugin-transform-jsx-to-htm', () => {
+	describe('import', () => {
+		test('import shortcut', () => {
+			expect(
+				compile(`(<div />);`, { import: 'htm/preact' })
+			).toBe('import { html } from "htm/preact";\nhtml`<div/>`;');
+		});
+
+		test('import shortcut, dotted tag', () => {
+			expect(
+				compile(`(<div />);`, { tag: 'html.bound', import: 'htm/preact' })
+			).toBe('import { html } from "htm/preact";\nhtml.bound`<div/>`;');
+		});
+
+		test('named import', () => {
+			expect(
+				compile(`(<div />);`, { import: { module: 'htm/preact', export: '$html' } })
+			).toBe('import { $html as html } from "htm/preact";\nhtml`<div/>`;');
+		});
+
+		test('named import, dotted tag', () => {
+			expect(
+				compile(`(<div />);`, { tag: 'html.bound', import: { module: 'htm/preact', export: '$html' } })
+			).toBe('import { $html as html } from "htm/preact";\nhtml.bound`<div/>`;');
+		});
+
+		test('default import', () => {
+			expect(
+				compile(`(<div />);`, { import: { module: 'htm/preact', export: 'default' } })
+			).toBe('import html from "htm/preact";\nhtml`<div/>`;');
+		});
+
+		test('namespace import', () => {
+			expect(
+				compile(`(<div />);`, { import: { module: 'htm/preact', export: '*' } })
+			).toBe('import * as html from "htm/preact";\nhtml`<div/>`;');
+		});
+
+		test('no import without JSX', () => {
+			expect(
+				compile(`false;`, { import: 'htm/preact' })
+			).toBe('false;');
+		});
+	});
+
 	describe('elements and text', () => {
 		test('single named element', () => {
 			expect(


### PR DESCRIPTION
This pull request adds an option to the babel-plugin-transform-jsx-to-htm for importing the tag. The option name is `import` and it can have three kinds of values: `false`, an **object** or a **string**:

 * `false` is the default, any kind of importing won't happen and the plugin works as it previously did.

 * An **object** has two keys: `module` and `export`. `module` defines which module gets imported, and `export` defines which name from the module gets imported. If `export` is `"default"` then the default export gets imported and if `export` is `"*"` then the whole namespace gets imported. Examples:
    * `{ tag: "html", import: { module: "htm/preact", export: "html" } }` adds `import { html } from "htm/preact"` to the beginning of each file containing JSX.
    * `{ tag: "$html", import: { module: "htm/preact", export: "html" } }` adds `import { html as $html } from "htm/preact"`
    * `{ tag: "html", import: { module: "htm/preact", export: "default" } }` adds `import html from "htm/preact"`
    * `{ tag: "html", import: { module: "htm/preact", export: "*" } }` adds `import * as html from "htm/preact"`

    Dotted identifiers for the tag still work:
    * `{ tag: "html.bound", import: { module: "htm/preact", export: "*" } }` adds `import * as html from "htm/preact"`

  * A **string** like `{ tag: "html", import: "htm/preact" }` is a shorthand for `{ tag: "html", import: { module: "htm/preact", export: "html" }}`.

    Dotted identifiers once again work: `{ tag: "html.bound", import: "htm/preact" }` is a shorthand for `{ tag: "html.bound", import: { module: "htm/preact", export: "html" }}`

Related tests are added.