### PR TITLE
Fix mini builds, add the .mjs file extension to module aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "npm run -s build:main && npm run -s build:mini && npm run -s build:preact && npm run -s build:react && npm run -s build:babel && npm run -s build:babel-transform-jsx",
     "build:main": "microbundle src/index.mjs -f es,umd --no-sourcemap --target web && microbundle src/cjs.mjs -f iife --no-sourcemap --target web",
-    "build:mini": "microbundle src/index.mjs -o ./mini/index.js -f es,umd --no-sourcemap --target web --alias ./constants=./constants-mini && microbundle src/cjs.mjs -o ./mini/index.js -f iife --no-sourcemap --target web --alias ./constants=./constants-mini",
+    "build:mini": "microbundle src/index.mjs -o ./mini/index.js -f es,umd --no-sourcemap --target web --alias ./constants.mjs=./constants-mini.mjs && microbundle src/cjs.mjs -o ./mini/index.js -f iife --no-sourcemap --target web --alias ./constants.mjs=./constants-mini.mjs",
     "build:preact": "cd src/integrations/preact && npm run build",
     "build:react": "cd src/integrations/react && npm run build",
     "build:babel": "cd packages/babel-plugin-htm && npm run build",


### PR DESCRIPTION
This pull request fixes the mini builds that weren't as mini as they could be. The mini versions were built by microbundle with the parameter `--alias ./constants=./constants-mini`. However, the `.mjs` file extensions should also be included there, because actual import is `import { MINI } from './constants.mjs'` (note the `.mjs` there).

Props to @developit for spotting the extra code in https://unpkg.com/htm@2.1.0/mini/index.mjs (look for the pieces of code mentioning `Map`, they shouldn't be there).