### PR TITLE
babel-plugin-transform-jsx-to-htm: remove package.json module field

### DIFF
--- a/packages/babel-plugin-transform-jsx-to-htm/package.json
+++ b/packages/babel-plugin-transform-jsx-to-htm/package.json
@@ -3,7 +3,6 @@
 	"version": "1.0.0",
 	"description": "Babel plugin to compile JSX to Tagged Templates.",
 	"main": "dist/babel-plugin-transform-jsx-to-htm.js",
-	"module": "dist/babel-plugin-transform-jsx-to-htm.mjs",
 	"scripts": {
 		"build": "microbundle index.mjs -f es,cjs --target node --no-compress --no-sourcemap",
 		"prepare": "npm run build"

--- a/packages/babel-plugin-transform-jsx-to-htm/package.json
+++ b/packages/babel-plugin-transform-jsx-to-htm/package.json
@@ -4,7 +4,7 @@
 	"description": "Babel plugin to compile JSX to Tagged Templates.",
 	"main": "dist/babel-plugin-transform-jsx-to-htm.js",
 	"scripts": {
-		"build": "microbundle index.mjs -f es,cjs --target node --no-compress --no-sourcemap",
+		"build": "microbundle index.mjs -f cjs --target node --no-compress --no-sourcemap",
 		"prepare": "npm run build"
 	},
 	"files": [


### PR DESCRIPTION
Fixes #83 

The ES module version does not works because the @babel/plugin-syntax-jsx dependency is published as a cjs module

Maybe can fix #86 