### PR TITLE
jsx-to-htm: leading underscore = reference tag

### DIFF
--- a/packages/babel-plugin-transform-jsx-to-htm/index.mjs
+++ b/packages/babel-plugin-transform-jsx-to-htm/index.mjs
@@ -144,7 +144,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 				}
 			}
 
-			if (name.match(/^[A-Z]/)) {
+			if (name.match(/^[_A-Z]/)) {
 				raw('</');
 				expr(t.identifier(name));
 				raw('>');

--- a/packages/babel-plugin-transform-jsx-to-htm/index.mjs
+++ b/packages/babel-plugin-transform-jsx-to-htm/index.mjs
@@ -92,7 +92,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 		const open = node.openingElement;
 		const { name } = open.name;
 
-		if (name.match(/^[A-Z]/)) {
+		if (name.match(/^[_A-Z]/)) {
 			raw('<');
 			expr(t.identifier(name));
 		}

--- a/packages/babel-plugin-transform-jsx-to-htm/index.mjs
+++ b/packages/babel-plugin-transform-jsx-to-htm/index.mjs
@@ -119,7 +119,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 			}
 
 			if (!isFragment) {
-				if (name.match(/^[$_A-Z]/)) {
+				if (name.match(/(^[$_A-Z]|\.)/)) {
 					raw('</');
 					expr(t.identifier(name));
 					raw('>');
@@ -142,7 +142,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 		const isFragment = name === 'React.Fragment';
 
 		if (!isFragment) {
-			if (name.match(/^[$_A-Z]/)) {
+			if (name.match(/(^[$_A-Z]|\.)/)) {
 				raw('<');
 				expr(t.identifier(name));
 			}


### PR DESCRIPTION
In JSX, a leading underscore in tag names denotes a reference tag (Component):

```js
var x = <_Foo />
// should output:
var x = html`<${_Foo} />`
```