### PR TITLE
Add dotted component name support for babel-plugin-transform-jsx-to-htm

### DIFF
--- a/packages/babel-plugin-transform-jsx-to-htm/index.mjs
+++ b/packages/babel-plugin-transform-jsx-to-htm/index.mjs
@@ -91,7 +91,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 	function getName(node) {
 		switch (node.type) {
 			case 'JSXMemberExpression':
-				return `${node.object.name}.${node.property.name}`
+				return `${node.object.name}.${node.property.name}`;
 		
 			default:
 				return node.name;
@@ -103,7 +103,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 		if (children && children.length !== 0) {
 			if (!isFragment) {
 				raw('>');
-			}			
+			}
 			for (let i = 0; i < children.length; i++) {
 				let child = children[i];
 				if (t.isStringLiteral(child)) {
@@ -129,7 +129,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 					raw(name);
 					raw('>');
 				}
-			}			
+			}
 		}
 		else if (!isFragment) {
 			raw('/>');
@@ -203,7 +203,8 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 			const template = t.templateLiteral(quasis, expressions);
 			const replacement = t.taggedTemplateExpression(tag, template);
 			path.replaceWith(replacement);
-		} else {
+		}
+		else {
 			processNode(path.node, path, true);
 		}
 	

--- a/packages/babel-plugin-transform-jsx-to-htm/index.mjs
+++ b/packages/babel-plugin-transform-jsx-to-htm/index.mjs
@@ -87,15 +87,25 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 		}));
 		buffer = '';
 	}
+
+	const FRAGMENT_EXPR = dottedIdentifier('React.Fragment');
+
+	function isFragmentName(node) {
+		return t.isNodesEquivalent(FRAGMENT_EXPR, node);
+	}
 	
-	function getName(node) {
-		switch (node.type) {
-			case 'JSXMemberExpression':
-				return `${node.object.name}.${node.property.name}`;
-		
-			default:
-				return node.name;
+	function isComponentName(node) {
+		return !t.isIdentifier(node) || node.name.match(/^[$_A-Z]/);
+	}
+	
+	function getNameExpr(node) {
+		if (!t.isJSXMemberExpression(node)) {
+			return t.identifier(node.name);
 		}
+		return t.memberExpression(
+			getNameExpr(node.object),
+			t.identifier(node.property.name)
+		);
 	}
 
 	function processChildren(node, name, isFragment) {
@@ -119,14 +129,14 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 			}
 
 			if (!isFragment) {
-				if (name.match(/(^[$_A-Z]|\.)/)) {
+				if (isComponentName(name)) {
 					raw('</');
-					expr(t.identifier(name));
+					expr(name);
 					raw('>');
 				}
 				else {
 					raw('</');
-					raw(name);
+					raw(name.name);
 					raw('>');
 				}
 			}
@@ -138,17 +148,17 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 
 	function processNode(node, path, isRoot) {
 		const open = node.openingElement;
-		const name = getName(open.name);
-		const isFragment = name === 'React.Fragment';
-
+		const name = getNameExpr(open.name);
+		const isFragment = isFragmentName(name);
+		
 		if (!isFragment) {
-			if (name.match(/(^[$_A-Z]|\.)/)) {
+			if (isComponentName(name)) {
 				raw('<');
-				expr(t.identifier(name));
+				expr(name);
 			}
 			else {
 				raw('<');
-				raw(name);
+				raw(name.name);
 			}
 			
 			if (open.attributes) {
@@ -198,7 +208,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 		expressions.length = 0;
 	
 		if (isFragment) {
-			processChildren(path.node, '', true);
+			processChildren(path.node, null, true);
 			commit();
 			const template = t.templateLiteral(quasis, expressions);
 			const replacement = t.taggedTemplateExpression(tag, template);

--- a/test/babel-transform-jsx.test.mjs
+++ b/test/babel-transform-jsx.test.mjs
@@ -79,6 +79,16 @@ describe('babel-plugin-transform-jsx-to-htm', () => {
 			).toBe('html`<${Foo}>a</${Foo}>`;');
 		});
 
+		test('dotted component element', () => {
+			expect(
+				compile('(<a.b.c />);')
+			).toBe('html`<${a.b.c}/>`;');
+
+			expect(
+				compile('(<a.b.c>a</a.b.c>);')
+			).toBe('html`<${a.b.c}>a</${a.b.c}>`;');
+		});
+
 		test('static text', () => {
 			expect(
 				compile(`(<div>Hello</div>);`)

--- a/test/babel-transform-jsx.test.mjs
+++ b/test/babel-transform-jsx.test.mjs
@@ -67,6 +67,22 @@ describe('babel-plugin-transform-jsx-to-htm', () => {
 			expect(
 				compile('(<div>a</div>);')
 			).toBe('html`<div>a</div>`;');
+			
+			expect(
+				compile('(<div$ />);')
+			).toBe('html`<div$/>`;');
+
+			expect(
+				compile('(<div$>a</div$>);')
+			).toBe('html`<div$>a</div$>`;');
+			
+			expect(
+				compile('(<div_ />);')
+			).toBe('html`<div_/>`;');
+
+			expect(
+				compile('(<div_>a</div_>);')
+			).toBe('html`<div_>a</div_>`;');
 		});
 
 		test('single component element', () => {
@@ -77,6 +93,38 @@ describe('babel-plugin-transform-jsx-to-htm', () => {
 			expect(
 				compile('(<Foo>a</Foo>);')
 			).toBe('html`<${Foo}>a</${Foo}>`;');
+
+			expect(
+				compile('(<$ />);')
+			).toBe('html`<${$}/>`;');
+
+			expect(
+				compile('(<$>a</$>);')
+			).toBe('html`<${$}>a</${$}>`;');
+			
+			expect(
+				compile('(<_ />);')
+			).toBe('html`<${_}/>`;');
+
+			expect(
+				compile('(<_>a</_>);')
+			).toBe('html`<${_}>a</${_}>`;');
+			
+			expect(
+				compile('(<_foo />);')
+			).toBe('html`<${_foo}/>`;');
+
+			expect(
+				compile('(<_foo>a</_foo>);')
+			).toBe('html`<${_foo}>a</${_foo}>`;');
+			
+			expect(
+				compile('(<$foo />);')
+			).toBe('html`<${$foo}/>`;');
+
+			expect(
+				compile('(<$foo>a</$foo>);')
+			).toBe('html`<${$foo}>a</${$foo}>`;');
 		});
 
 		test('dotted component element', () => {


### PR DESCRIPTION
This pull request is an offshoot of #85 (by @blikblum), and modifies babel-plugin-transform-jsx-to-htm to support dotted component names like `<a.b.c />`.

The new logic considers all element names that either start with a capital letter, `$` or `_` or are not valid identifiers as component references. It should be noted that dotted names (member expressions) such as `a.b.c` are not valid identifiers, and are therefore considered to be component references.

This PR also adds tests for dotted components. There are also new tests for special-cased component names such as `$foo` and `_foo` (introduced in #92).