### PR TITLE
Add native object spread support to babel-plugin-htm

### DIFF
--- a/test/babel.test.mjs
+++ b/test/babel.test.mjs
@@ -46,6 +46,17 @@ describe('htm/babel', () => {
 				]
 			}).code
 		).toBe(`h("a",Object.assign({b:2},{c:3}),"d: ",4);`);
+		
+		expect(
+			transform('html`<a b=${2} ...${{ c: 3 }}>d: ${4}</a>`;', {
+				...options,
+				plugins: [
+					[htmBabelPlugin, {
+						useNativeSpread: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",{b:2,...{c:3}},"d: ",4);`);
 	});
 
 	test('spread a single variable', () => {
@@ -54,6 +65,17 @@ describe('htm/babel', () => {
 				...options,
 				plugins: [
 					htmBabelPlugin
+				]
+			}).code
+		).toBe(`h("a",foo);`);
+		
+		expect(
+			transform('html`<a ...${foo}></a>`;', {
+				...options,
+				plugins: [
+					[htmBabelPlugin, {
+						useNativeSpread: true
+					}]
 				]
 			}).code
 		).toBe(`h("a",foo);`);
@@ -70,6 +92,17 @@ describe('htm/babel', () => {
 				]
 			}).code
 		).toBe(`h("a",Object.assign({},foo,bar));`);
+		
+		expect(
+			transform('html`<a ...${foo} ...${bar}></a>`;', {
+				...options,
+				plugins: [
+					[htmBabelPlugin, {
+						useNativeSpread: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",{...foo,...bar});`);
 	});
 
 	test('property followed by a spread', () => {
@@ -83,6 +116,17 @@ describe('htm/babel', () => {
 				]
 			}).code
 		).toBe(`h("a",Object.assign({b:"1"},foo));`);
+		
+		expect(
+			transform('html`<a b="1" ...${foo}></a>`;', {
+				...options,
+				plugins: [
+					[htmBabelPlugin, {
+						useNativeSpread: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",{b:"1",...foo});`);
 	});
 
 	test('spread followed by a property', () => {
@@ -96,6 +140,17 @@ describe('htm/babel', () => {
 				]
 			}).code
 		).toBe(`h("a",Object.assign({},foo,{b:"1"}));`);
+		
+		expect(
+			transform('html`<a ...${foo} b="1"></a>`;', {
+				...options,
+				plugins: [
+					[htmBabelPlugin, {
+						useNativeSpread: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",{...foo,b:"1"});`);
 	});
 
 	test('mix-and-match spreads', () => {
@@ -109,6 +164,17 @@ describe('htm/babel', () => {
 				]
 			}).code
 		).toBe(`h("a",Object.assign({b:"1"},foo,{c:2},{d:3}));`);
+		
+		expect(
+			transform('html`<a b="1" ...${foo} c=${2} ...${{d:3}}></a>`;', {
+				...options,
+				plugins: [
+					[htmBabelPlugin, {
+						useNativeSpread: true
+					}]
+				]
+			}).code
+		).toBe(`h("a",{b:"1",...foo,c:2,...{d:3}});`);
 	});
 
 	describe('{variableArity:false}', () => {


### PR DESCRIPTION
This pull request adds support for native object spreads for babel-plugin-htm. Setting the new `useNativeSpread` parameter to `true` turns the support on. When the support is on input such as `<div ...${a} b=${1} ...${c} />` would produce `h("div", {...a, b:1, ...c})` instead of `h("div", Object.assign({}, a, {b:1}, c))` .

This PR also adds tests for the new functionality.