### PR TITLE
Remove peerDependencies to avoid warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,9 +78,5 @@
     "microbundle": "^0.10.1",
     "preact": "^8.4.2",
     "react": "^16.8.3"
-  },
-  "dependencies": {},
-  "peerDependencies": {
-    "preact": "*"
   }
 }


### PR DESCRIPTION
It's not great, but we weren't going to be using them to limit version compat anyway.
Fixes #94.