### PR TITLE
Don't build react/index.mjs

### DIFF
--- a/src/integrations/react/package.json
+++ b/src/integrations/react/package.json
@@ -1,12 +1,11 @@
 {
 	"name": "htm_react",
-	"module": "index.mjs",
 	"main": "index.js",
-	"umd:main": "index.js",
-	"unpkg": "index.js",
+	"umd:main": "index.umd.js",
+	"unpkg": "index.umd.js",
 	"scripts": {
 		"build": "npm run -s build:main && npm run -s build:static",
-		"build:main": "microbundle index.mjs -o ../../../react/index.js -f es,umd --external react,htm --no-sourcemap --target web",
+		"build:main": "microbundle index.mjs -o ../../../react/index.js -f cjs,umd --external react,htm --no-sourcemap --target web",
 		"build:static": "cp index.d.ts package.json ../../../react/"
 	}
 }


### PR DESCRIPTION
This pull request attempts to fix issue #103 by not building the bundled `react/index.mjs` file, instead going for CJS build `react/index.js` and UMD build `react/index.umd.js`.

Fixes #103.