### PR TITLE
Prepare README.md and package.json files for a new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It uses standard JavaScript [Tagged Templates] and works in [all modern browsers
 
 ⚛️ **< 500 bytes** when used with Preact _(thanks gzip 🌈)_
 
-🥚 **< 400 byte** `htm/mini` version
+🥚 **< 420 byte** `htm/mini` version
 
 🏅 **0 bytes** if compiled using [babel-plugin-htm]
 
@@ -45,6 +45,7 @@ Here's some ergonomic features you get for free that aren't present in JSX:
 - Component end-tags: `<${Footer}>footer content<//>`
 - Syntax highlighting and language support via the [lit-html VSCode extension] and [vim-jsx-pretty plugin].
 - Multiple root element (fragments): `<div /><div />`
+- Support for HTML-style comments: `<div><!-- comment --></div>`
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htm",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "The Tagged Template syntax for Virtual DOM. Only browser-compatible syntax.",
   "main": "dist/htm.js",
   "umd:main": "dist/htm.umd.js",

--- a/packages/babel-plugin-htm/package.json
+++ b/packages/babel-plugin-htm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "babel-plugin-htm",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Babel plugin to compile htm's Tagged Template syntax to hyperscript or inline VNodes.",
 	"main": "dist/babel-plugin-htm.js",
 	"module": "dist/babel-plugin-htm.mjs",
@@ -33,7 +33,7 @@
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/developit/htm/tree/master/packages/babel-plugin-htm",
 	"dependencies": {
-		"htm": "^2.0.0"
+		"htm": "^2.2.0"
 	},
 	"devDependencies": {
 		"microbundle": "^0.10.1"

--- a/packages/babel-plugin-transform-jsx-to-htm/package.json
+++ b/packages/babel-plugin-transform-jsx-to-htm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "babel-plugin-transform-jsx-to-htm",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Babel plugin to compile JSX to Tagged Templates.",
 	"main": "dist/babel-plugin-transform-jsx-to-htm.js",
 	"scripts": {
@@ -32,7 +32,7 @@
 	"homepage": "https://github.com/developit/htm/tree/master/packages/babel-plugin-transform-jsx-to-htm",
 	"dependencies": {
 		"@babel/plugin-syntax-jsx": "^7.2.0",
-		"htm": "^2.0.0"
+		"htm": "^2.2.0"
 	},
 	"devDependencies": {
 		"microbundle": "^0.10.1"


### PR DESCRIPTION
This pull request prepares the repository for the next release:
 * Update the package.json files to the version number 2.2.0, except for `babel-plugin-transform-jsx-to-htm`s being bumped to 1.1.0.
 * Update the main README.md file to mention the HTML comment support and the slightly increased `htm/mini` size.