### PR TITLE
Track static parts of the generated VDOM

### DIFF
--- a/src/build.mjs
+++ b/src/build.mjs
@@ -111,7 +111,7 @@ export const evaluate = (h, built, fields, args) => {
 			args.push(h.apply(childStaticFlags, value));
 			// Zero out `staticFlags`'s second-to-lowest bit if the whole subtree rooted
 			// at the child (including the child) isn't static.
-			staticFlags &= (childStaticFlags & (childStaticFlags << 1)) | 1;
+			staticFlags &= ((childStaticFlags + 1) >> 1) | 1;
 		}
 		else {
 			// type === CHILD_APPEND

--- a/src/build.mjs
+++ b/src/build.mjs
@@ -36,30 +36,31 @@ export const treeify = (built, fields) => {
 		const children = [];
 
 		for (let i = 1; i < built.length; i++) {
-			const field = built[i++];
+			const type = built[i++];
+			const field = built[i];
 			const value = typeof field === 'number' ? fields[field - 1] : field;
 
-			if (built[i] === TAG_SET) {
+			if (type === TAG_SET) {
 				tag = value;
 			}
-			else if (built[i] === PROPS_ASSIGN) {
+			else if (type === PROPS_ASSIGN) {
 				props.push(value);
 				currentProps = null;
 			}
-			else if (built[i] === PROP_SET) {
+			else if (type === PROP_SET) {
 				if (!currentProps) {
 					currentProps = Object.create(null);
 					props.push(currentProps);
 				}
 				currentProps[built[++i]] = [value];
 			}
-			else if (built[i] === PROP_APPEND) {
+			else if (type === PROP_APPEND) {
 				currentProps[built[++i]].push(value);
 			}
-			else if (built[i] === CHILD_RECURSE) {
+			else if (type === CHILD_RECURSE) {
 				children.push(_treeify(value));
 			}
-			else if (built[i] === CHILD_APPEND) {
+			else if (type === CHILD_APPEND) {
 				children.push(value);
 			}
 		}

--- a/test/statics-tracking.test.mjs
+++ b/test/statics-tracking.test.mjs
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import htm from '../src/index.mjs';
+
+const html = htm.bind(function(tag, props, ...children) {
+	return [this, ...children];
+});
+
+describe('htm statics tracking', () => {
+	test('basic functionality', () => {
+		expect(html``).toEqual(undefined);
+		expect(html`<div />`).toEqual([3]);
+		expect(html`<div>${'a'}</div>`).toEqual([1, 'a']);
+		expect(html`<div x=1 />`).toEqual([3]);
+		expect(html`<div x=1>${'a'}</div>`).toEqual([1, 'a']);
+		expect(html`<div x=${1} />`).toEqual([0]);
+		expect(html`<div x=${1}>${'a'}</div>`).toEqual([0, 'a']);
+	});
+
+	test('dynamic root, static descendants', () => {
+		expect(html`<div x=${1}><a><b /></a></div>`).toEqual([0, [3, [3]]]);
+	});
+
+	test('mixed static + dynamic descendants', () => {
+		expect(html`<div><a x=1 /><a x=${1}/></div>`).toEqual([1, [3], [0]]);
+		expect(html`<div><a><b x=1 /></a><a><b x=${1}/></a></div>`).toEqual([1, [3, [3]], [1, [0]]]);
+	});
+});

--- a/test/statics-tracking.test.mjs
+++ b/test/statics-tracking.test.mjs
@@ -24,16 +24,16 @@ describe('htm statics tracking', () => {
 		expect(html`<div>${'a'}</div>`).toEqual([1, 'a']);
 		expect(html`<div x=1 />`).toEqual([3]);
 		expect(html`<div x=1>${'a'}</div>`).toEqual([1, 'a']);
-		expect(html`<div x=${1} />`).toEqual([0]);
+		expect(html`<div x=${1} />`).toEqual([2]);
 		expect(html`<div x=${1}>${'a'}</div>`).toEqual([0, 'a']);
 	});
 
 	test('dynamic root, static descendants', () => {
-		expect(html`<div x=${1}><a><b /></a></div>`).toEqual([0, [3, [3]]]);
+		expect(html`<div x=${1}><a><b /></a></div>`).toEqual([2, [3, [3]]]);
 	});
 
 	test('mixed static + dynamic descendants', () => {
-		expect(html`<div><a x=1 /><a x=${1}/></div>`).toEqual([1, [3], [0]]);
-		expect(html`<div><a><b x=1 /></a><a><b x=${1}/></a></div>`).toEqual([1, [3, [3]], [1, [0]]]);
+		expect(html`<div><a x=1 /><a x=${1} /></div>`).toEqual([1, [3], [2]]);
+		expect(html`<div><a><b x=1 /></a><a><b x=${1}/></a></div>`).toEqual([1, [3, [3]], [1, [2]]]);
 	});
 });


### PR DESCRIPTION
This pull request modifies how the `h` functions are called (in the non-mini build) in order to track whether the element evaluated by `h` is _static_. When we talk about _static_ elements in this context we mean elements whose tag or props are not in any way based on dynamic values. Text nodes are static if their text is not based on a dynamic value.

In `h` function calls made by HTM `this` will be a number. The number's two lowest bits are used to signal the following things:
 * If the lowest bit is set it means that the element that `h` is currently evaluating is static. The element's descendants may or may not be static.
 * If the second-to-lowest bit is set it means that all the element's descendants are static. The element itself may or may not be static.

In practice this means that `h`'s `this` will be `0b00` when the element itself _and_ one or more of its descendants is based on dynamic values. Conversely, `this` will be `0b11` when the element itself _and_ all of its (zero or more) descendants are static. When the element itself is static but has dynamic descendants `this` will be `0b01`, and when the element itself is dynamic but all of its (zero or more) descendants are static `this` will be `0b10`.

This pull request also adds some rudimentary tests for statics tracking. The size of the Brotli-compressed `htm.module.js.br` increases by 24 bytes (596 B -> 620 B). The highest results in the "usage" benchmark are less than 2% lower compared to the master branch's highest results.