### PR TITLE
Add TypeScript typing files for htm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "module": "dist/htm.module.js",
   "scripts": {
     "build": "npm run -s build:main && npm run -s build:mini && npm run -s build:preact && npm run -s build:react && npm run -s build:babel && npm run -s build:babel-transform-jsx && npm run -s build:mjsalias",
-    "build:main": "microbundle src/index.mjs -f es,umd --no-sourcemap --target web && microbundle src/cjs.mjs -f iife --no-sourcemap --target web",
-    "build:mini": "microbundle src/index.mjs -o ./mini/index.js -f es,umd --no-sourcemap --target web --alias ./constants.mjs=./constants-mini.mjs && microbundle src/cjs.mjs -o ./mini/index.js -f iife --no-sourcemap --target web --alias ./constants.mjs=./constants-mini.mjs",
+    "build:main": "microbundle src/index.mjs -f es,umd --no-sourcemap --target web && microbundle src/cjs.mjs -f iife --no-sourcemap --target web && cp src/index.d.ts dist",
+    "build:mini": "microbundle src/index.mjs -o ./mini/index.js -f es,umd --no-sourcemap --target web --alias ./constants.mjs=./constants-mini.mjs && microbundle src/cjs.mjs -o ./mini/index.js -f iife --no-sourcemap --target web --alias ./constants.mjs=./constants-mini.mjs && cp src/index.d.ts mini",
     "build:preact": "cd src/integrations/preact && npm run build",
     "build:react": "cd src/integrations/react && npm run build",
     "build:babel": "cd packages/babel-plugin-htm && npm run build",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,5 @@
+export default {
+  bind<HResult>(
+    h: (type: any, props: Record<string, any>, ...children: any[]) => HResult
+  ): (strings: TemplateStringsArray, ...values: any[]) => HResult | HResult[];
+};


### PR DESCRIPTION
This pull request adds basic TypeScript type declarations for `htm`.

The typings are rather minimal. Only `htm`'s default export is typed, and it's just an object with one method: `bind(h)`. Here `h` is the pragma function and its argument types are quite lax for convenience's sake. `bind`'s result is a function whose return type is based on `h`'s return type:

```ts
// const html: (strings: TemplateStringsArray, ...values: any[]) => number | number[]
const html = htm.bind((type, props, ...children) => {
   return children.length;
});
```

The type declarations are located in `src/index.d.ts`. That file is then copied to `dist/index.d.ts` and `mini/index.d.ts` as a part of the build process, after Microbundle has done its magic.