### PR TITLE
Update htm/preact/standalone to Preact X

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-config-developit": "^1.1.1",
     "jest": "^24.1.0",
     "microbundle": "^0.10.1",
-    "preact": "^8.4.2",
+    "preact": "^10.0.0",
     "react": "^16.8.3"
   }
 }

--- a/src/integrations/preact/index.mjs
+++ b/src/integrations/preact/index.mjs
@@ -11,12 +11,8 @@
  * limitations under the License.
  */
 
-import { h, Component, render as preactRender } from 'preact';
+import { h, Component, render } from 'preact';
 import htm from 'htm';
-
-function render(tree, parent) {
-	preactRender(tree, parent, parent.firstElementChild);
-}
 
 const html = htm.bind(h);
 

--- a/test/preact.test.mjs
+++ b/test/preact.test.mjs
@@ -83,7 +83,7 @@ describe('htm/preact', () => {
 		scratch.innerHTML = '';
 
 		render(html`<div is-before="blah" ...${props} />`, scratch);
-		expect(scratch.innerHTML).toBe(`<div is-before="blah" a="1" b="2" c="3"></div>`);
+		expect(scratch.innerHTML).toBe(`<div a="1" b="2" c="3" is-before="blah"></div>`);
 		scratch.innerHTML = '';
 
 		render(html`<div ...${props} is-after />`, scratch);
@@ -92,7 +92,7 @@ describe('htm/preact', () => {
 		scratch.innerHTML = '';
 
 		render(html`<div is-before ...${props} is-after="blah" />`, scratch);
-		expect(scratch.innerHTML).toBe(`<div is-before="true" a="1" b="2" c="3" is-after="blah"></div>`);
+		expect(scratch.innerHTML).toBe(`<div a="1" b="2" c="3" is-after="blah" is-before="true"></div>`);
 		scratch.innerHTML = '';
 
 		render(html`<div ...${props} ...${other} />`, scratch);


### PR DESCRIPTION
This pull request updates the Preact version from which `htm/preact/standalone.*` files are built to `^10.0.0`.

One test needed to be modified, as it depended on a specific attribute order in the output.