### PR TITLE
Use only Map for caching & add static subtrees caching

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -14,29 +14,15 @@
 import { MINI } from './constants.mjs';
 import { build, evaluate } from './build.mjs';
 
-const getCacheMap = (statics) => {
-	let tpl = CACHE.get(statics);
-	if (!tpl) {
-		CACHE.set(statics, tpl = build(statics));
-	}
-	return tpl;
-};
-
-const getCacheKeyed = (statics) => {
-	let key = '';
-	for (let i = 0; i < statics.length; i++) {
-		key += statics[i].length + '-' + statics[i];
-	}
-	return CACHE[key] || (CACHE[key] = build(statics));
-};
-
-const USE_MAP = !MINI && typeof Map === 'function';
-const CACHE = USE_MAP ? new Map() : {};
-const getCache = USE_MAP ? getCacheMap : getCacheKeyed;
+const CACHE = new Map();
 
 const cached = function(statics) {
-	const res = evaluate(this, getCache(statics), arguments, []);
-	return res.length > 1 ? res : res[0];
+	let tmp = CACHE.get(statics);
+	if (!tmp) {
+		CACHE.set(statics, tmp = build(statics));
+	}
+	tmp = evaluate(this, tmp, arguments, []);
+	return tmp.length > 1 ? tmp : tmp[0];
 };
 
 export default MINI ? build : cached;

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -14,15 +14,17 @@
 import { MINI } from './constants.mjs';
 import { build, evaluate } from './build.mjs';
 
-const CACHE = new Map();
+const regular = h => {
+	const cache = new Map();
 
-const cached = function(statics) {
-	let tmp = CACHE.get(statics);
-	if (!tmp) {
-		CACHE.set(statics, tmp = build(statics));
-	}
-	tmp = evaluate(this, tmp, arguments, []);
-	return tmp.length > 1 ? tmp : tmp[0];
+	return function(statics) {
+		let tmp = cache.get(statics);
+		if (!tmp) {
+			cache.set(statics, tmp = build(statics));
+		}
+		tmp = evaluate(h, tmp, arguments, []);
+		return tmp.length > 1 ? tmp : tmp[0];
+	};
 };
 
-export default MINI ? build : cached;
+export default MINI ? build : { bind: regular };

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -14,17 +14,16 @@
 import { MINI } from './constants.mjs';
 import { build, evaluate } from './build.mjs';
 
-const regular = h => {
-	const cache = new Map();
+const CACHES = new Map();
 
-	return function(statics) {
-		let tmp = cache.get(statics);
-		if (!tmp) {
-			cache.set(statics, tmp = build(statics));
-		}
-		tmp = evaluate(h, tmp, arguments, []);
-		return tmp.length > 1 ? tmp : tmp[0];
-	};
+const regular = function(statics) {
+	let tmp = CACHES.get(this);
+	if (!tmp) {
+		tmp = new Map();
+		CACHES.set(this, tmp);
+	}
+	tmp = evaluate(this, tmp.get(statics) || (tmp.set(statics, tmp = build(statics)), tmp), arguments, []);
+	return tmp.length > 1 ? tmp : tmp[0];
 };
 
-export default MINI ? build : { bind: regular };
+export default MINI ? build : regular;

--- a/test/statics-caching.test.mjs
+++ b/test/statics-caching.test.mjs
@@ -17,12 +17,23 @@ const h = (tag, props, ...children) => ({ tag, props, children });
 const html = htm.bind(h);
 
 describe('htm', () => {
-	test('caching', () => {
+	test('should cache static subtrees', () => {
 		const x = () => html`<div>a</div>`;
 		const a = x();
 		const b = x();
 		expect(a).toEqual({ tag: 'div', props: null, children: ['a'] });
 		expect(b).toEqual({ tag: 'div', props: null, children: ['a'] });
 		expect(a).toBe(b);
+	});
+
+	test('should have a different cache for each h', () => {
+		let tmp = htm.bind(() => 1);
+		const x = () => tmp`<div>a</div>`;
+		const a = x();
+		tmp = htm.bind(() => 2);
+		const b = x();
+
+		expect(a).toBe(1);
+		expect(b).toBe(2);
 	});
 });

--- a/test/statics-caching.test.mjs
+++ b/test/statics-caching.test.mjs
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import htm from '../src/index.mjs';
+
+const h = (tag, props, ...children) => ({ tag, props, children });
+const html = htm.bind(h);
+
+describe('htm', () => {
+	test('caching', () => {
+		const x = () => html`<div>a</div>`;
+		const a = x();
+		const b = x();
+		expect(a).toEqual({ tag: 'div', props: null, children: ['a'] });
+		expect(b).toEqual({ tag: 'div', props: null, children: ['a'] });
+		expect(a).toBe(b);
+	});
+});


### PR DESCRIPTION
This pull request modifies `htm`'s caching strategy in three major ways:

 * Use only `Map` for caching, getting rid of the previous fallback to string-keyed caching. This saves about 50 bytes in the brotli-compressed bundle.

 * Create a separate cache for each `htm.bind(h)` call, which allows us to...

 * Add static subtree caching. In short this means that HTM tracks the _staticness_ of subtrees it evaluates, and caches `h(...)` call results for static subtrees. In short it's kind of like a on-the-fly [@babel/plugin-transform-react-constant-elements](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements/) (though less clever as even immutable dynamic properties/tags/chidren will prevent caching).

## Static subtree caching

In this context by _static_ we mean a subtree where the root element and none of its descendants depend on dynamic values (an empty set of descendants is considered static). In the following example only the `span` element is static. This is because the `h1` element depends on a dynamic child value, `div` depends on a dynamic property value. `main`, while not directly dependent on a dynamic value, has non-static descendants (`h1` and `div`).

```js
html`
  <main>
    <h1>${"not static"}</h1>
    <div class=${foo}></div>
    <span>totally-static</span>
  </main>
`
```

The implementation takes advantage of the fact that `build(...)` uses the first index of the opcode lists it created for bookkeeping. Previously `evaluate(...)` just ignored the first element, but now `evaluate` repurposes the first element to store staticness info about the subtree that the opcode list represents.

The caching itself is done by rewriting the opcode list on-the-fly. Each new child that gets evaluated with `h` is represented in the opcode list as a slice like `CHILD_RECURSE, 0, [...omitted...]`. If the evaluated child `x = h(...)` is determined to be static then the slice gets rewritten in-place to `CHILD_APPEND, 0, x`. If the opcode list is re-evaluated at some later time then the `x` value is just reused, short-circuiting the evaluation process.

There are new tests to verify that subtree caching works.

## Breaking changes

Due to subtree caching `h` is now required to be a pure function, or at least pure enough that it's OK to skip re-evaluating static subtrees. This new requirement for `h` could be considered an API change.

The fact that there is no a fallback for environments where `Map` is not defined is a breaking change. However even IE 11 supports Maps, and in older environments it can be polyfilled.

The main interface for binding `h` functions with `htm.bind(h)` remains unchanges. This is however a trick - `htm.bind` is redefined by us to allow creating a new cache per `htm.bind` call. This is technically a breaking change, as `htm.call(h, ...)` doesn't work like previously. As a counterpoint, the usage of `htm.bind(h)` was the _documented_ way to use the library, while `htm.call(h, ...)` and others were not.

## Performance & size

The Brotli-compressed size of the library decreases by 25 bytes compared to the current master (596 B -> 571 B). The size of `htm/mini` remains unchanged though.

The performance downsides and benefits need more benchmarking, but here are some preliminary notes:

 * In the test:perf benchmark the worst-case scenario where every element is dynamic is about 4% slower compared to the current master.

 * Switching to a more realistic `h` implementation (`React.createElement`) the difference disappears.

 * Keeping the `React.createElement` as the `h` and modifying the benchmark to the following:
    ```js
    html`
      <div>
        <span>${1}</span>
        <span>totally-static</span>
      </div>
    `
    ```
    This PR's version is now about 42% _faster_ than the current master.

  * These benchmarks do not test diffing etc. at all, only VDOM node creation.