### PR TITLE
add preact hooks to the standalone bundle

### DIFF
--- a/src/integrations/preact/standalone.mjs
+++ b/src/integrations/preact/standalone.mjs
@@ -12,6 +12,7 @@
  */
 
 import { h, Component, render as preactRender } from 'preact';
+import { useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue } from 'preact/hooks';
 import htm from '../../index.mjs';
 
 function render(tree, parent) {
@@ -20,4 +21,4 @@ function render(tree, parent) {
 
 const html = htm.bind(h);
 
-export { h, html, render, Component };
+export { h, html, render, Component, useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue };


### PR DESCRIPTION
This adds exported preact/hooks functions to the standalone bundle, so that one can use htm + preact + useState etc from a single module.
I believe that Preact 10.0.0+ gains a lot from using hooks, also this functionality was requested in the relevant issue issue: https://github.com/developit/htm/issues/46#issuecomment-544104401
There might be a better way to resolve this, if so - I'd be happy to adjust the PR.