### PR TITLE
Boost text mode

### DIFF
--- a/src/build.mjs
+++ b/src/build.mjs
@@ -184,22 +184,22 @@ export const build = function(statics) {
 
 			if (mode === MODE_TEXT) {
 				// Boost text mode
-				let idx = statics[i].indexOf('<', j)
+				let idx = statics[i].indexOf('<', j);
 				if (idx < 0) {
-					buffer = statics[i].slice(j)
-					j = statics[i].length
+					buffer = statics[i].slice(j);
+					j = statics[i].length;
 				}
 				else {
-					buffer = statics[i].slice(j, idx)
-					j = idx
-					commit()
+					buffer = statics[i].slice(j, idx);
+					j = idx;
+					commit();
 					if (MINI) {
 						current = [current, '', null];
 					}
 					else {
 						current = [current];
 					}
-					mode = MODE_TAGNAME
+					mode = MODE_TAGNAME;
 				}
 			}
 			else if (mode === MODE_COMMENT) {

--- a/src/build.mjs
+++ b/src/build.mjs
@@ -183,19 +183,23 @@ export const build = function(statics) {
 			char = statics[i][j];
 
 			if (mode === MODE_TEXT) {
-				if (char === '<') {
-					// commit buffer
-					commit();
+				// Boost text mode
+				let idx = statics[i].indexOf('<', j)
+				if (idx < 0) {
+					buffer = statics[i].slice(j)
+					j = statics[i].length
+				}
+				else {
+					buffer = statics[i].slice(j, idx)
+					j = idx
+					commit()
 					if (MINI) {
 						current = [current, '', null];
 					}
 					else {
 						current = [current];
 					}
-					mode = MODE_TAGNAME;
-				}
-				else {
-					buffer += char;
+					mode = MODE_TAGNAME
 				}
 			}
 			else if (mode === MODE_COMMENT) {


### PR DESCRIPTION
Since we know that `MODE_TEXT` ignores all characters except for `<`, we can fast-forward to the first `<`.

This ~~reduces 8 bytes of built code and~~ adds ~5% (some) performance.

Same can be done for:
* [ ] `MODE_COMMENT`
* [ ] `quote`

@developit @jviide 