### PR TITLE
Prepare README.md and package.json files for v3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ The original goal for `htm` was to create a wrapper around Preact that felt natu
 
 This meant giving up JSX, and the closest alternative was [Tagged Templates]. So, I wrote this library to patch up the differences between the two as much as possible. As it turns out, the technique is framework-agnostic, so it should work great with most Virtual DOM libraries.
 
-As of 3.0.0, `htm` is stable, well-tested and ready for production use.
+`htm` is stable, fast, well-tested and ready for production use.
 
 [Tagged Templates]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates
 [lit-html]: https://github.com/Polymer/lit-html

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you're using Preact or React, we've included off-the-shelf bindings to make y
 They also have the added benefit of sharing a template cache across all modules.
 
 ```js
-import { render } from 'preact'; 
+import { render } from 'preact';
 import { html } from 'htm/preact';
 render(html`<a href="/">Hello!</a>`, document.body);
 ```
@@ -83,7 +83,7 @@ render(html`<a href="/">Hello!</a>`, document.body);
 Similarly, for React:
 
 ```js
-import ReactDOM from 'react-dom'; 
+import ReactDOM from 'react-dom';
 import { html } from 'htm/react';
 ReactDOM.render(html`<a href="/">Hello!</a>`, document.body);
 ```
@@ -266,7 +266,7 @@ The original goal for `htm` was to create a wrapper around Preact that felt natu
 
 This meant giving up JSX, and the closest alternative was [Tagged Templates]. So, I wrote this library to patch up the differences between the two as much as possible. As it turns out, the technique is framework-agnostic, so it should work great with most Virtual DOM libraries.
 
-As of 2.1.0, `htm` is stable, well-tested and ready for production use.
+As of 3.0.0, `htm` is stable, well-tested and ready for production use.
 
 [Tagged Templates]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates
 [lit-html]: https://github.com/Polymer/lit-html

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ console.log(html`
 
 The original goal for `htm` was to create a wrapper around Preact that felt natural for use untranspiled in the browser. I wanted to use Virtual DOM, but I wanted to eschew build tooling and use ES Modules directly.
 
-This meant giving up JSX, and the closest alternative was [Tagged Templates]. So, I wrote this library to patch up the differences between the two as much as possible. As it turns out, the technique is framework-agnostic, so it should work great with most Virtual DOM libraries.
+ This meant giving up JSX, and the closest alternative was [Tagged Templates]. So, I wrote this library to patch up the differences between the two as much as possible. The technique turns out to be framework-agnostic, so it should work great with any library or renderer that works with JSX.
 
 `htm` is stable, fast, well-tested and ready for production use.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htm",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "description": "The Tagged Template syntax for Virtual DOM. Only browser-compatible syntax.",
   "main": "dist/htm.js",
   "umd:main": "dist/htm.umd.js",

--- a/packages/babel-plugin-htm/package.json
+++ b/packages/babel-plugin-htm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "babel-plugin-htm",
-	"version": "2.2.0",
+	"version": "3.0.0",
 	"description": "Babel plugin to compile htm's Tagged Template syntax to hyperscript or inline VNodes.",
 	"main": "dist/babel-plugin-htm.js",
 	"module": "dist/babel-plugin-htm.mjs",
@@ -33,7 +33,7 @@
 	"license": "Apache-2.0",
 	"homepage": "https://github.com/developit/htm/tree/master/packages/babel-plugin-htm",
 	"dependencies": {
-		"htm": "^2.2.0"
+		"htm": "^3.0.0"
 	},
 	"devDependencies": {
 		"microbundle": "^0.10.1"

--- a/packages/babel-plugin-transform-jsx-to-htm/package.json
+++ b/packages/babel-plugin-transform-jsx-to-htm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "babel-plugin-transform-jsx-to-htm",
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"description": "Babel plugin to compile JSX to Tagged Templates.",
 	"main": "dist/babel-plugin-transform-jsx-to-htm.js",
 	"scripts": {
@@ -32,7 +32,7 @@
 	"homepage": "https://github.com/developit/htm/tree/master/packages/babel-plugin-transform-jsx-to-htm",
 	"dependencies": {
 		"@babel/plugin-syntax-jsx": "^7.2.0",
-		"htm": "^2.2.0"
+		"htm": "^3.0.0"
 	},
 	"devDependencies": {
 		"microbundle": "^0.10.1"


### PR DESCRIPTION
This pull request prepares for the v3 release by:
 * bumping the htm package version to 3.0.0
 * bumping the babel-plugin-transform-jsx-to-htm version to 3.0.0 (from 2.2.0) and requiring htm ^3.0.0
 * bumping the babel-plugin-htm version to 2.0.0 from 1.1.0 and requiring htm ^3.0.0
 * adding minor tweaks to README.md