### PR TITLE
v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htm",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The Tagged Template syntax for Virtual DOM. Only browser-compatible syntax.",
   "main": "dist/htm.js",
   "umd:main": "dist/htm.umd.js",


### PR DESCRIPTION
Bump up the package.json version number v3.0.1. v3.0.0 got released without the built files due to Yours Truly incorrectly running the release scripts.