### PR TITLE
Fix typing file name & package.json field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "dist/htm.js",
   "umd:main": "dist/htm.umd.js",
   "module": "dist/htm.module.js",
+  "types": "dist/htm.d.ts",
   "scripts": {
     "build": "npm run -s build:main && npm run -s build:mini && npm run -s build:preact && npm run -s build:react && npm run -s build:babel && npm run -s build:babel-transform-jsx && npm run -s build:mjsalias",
-    "build:main": "microbundle src/index.mjs -f es,umd --no-sourcemap --target web && microbundle src/cjs.mjs -f iife --no-sourcemap --target web && cp src/index.d.ts dist",
+    "build:main": "microbundle src/index.mjs -f es,umd --no-sourcemap --target web && microbundle src/cjs.mjs -f iife --no-sourcemap --target web && cp src/index.d.ts dist/htm.d.ts",
     "build:mini": "microbundle src/index.mjs -o ./mini/index.js -f es,umd --no-sourcemap --target web --alias ./constants.mjs=./constants-mini.mjs && microbundle src/cjs.mjs -o ./mini/index.js -f iife --no-sourcemap --target web --alias ./constants.mjs=./constants-mini.mjs && cp src/index.d.ts mini",
     "build:preact": "cd src/integrations/preact && npm run build",
     "build:react": "cd src/integrations/react && npm run build",


### PR DESCRIPTION
This pull request fixes the TypeScript typings file name from "dist/index.d.ts" to "dist/htm.d.ts". It also adds the package.json field "types" to explicitly point to the typings file.