### PR TITLE
Add a test for forcing subtree staticness

### DIFF
--- a/test/statics-caching.test.mjs
+++ b/test/statics-caching.test.mjs
@@ -89,4 +89,25 @@ describe('htm', () => {
 			expect(html`<div x=${1}><a y=${2} /><b /></div>`).toBe(3);
 		});
 	});
+
+	describe('the h function should be able to modify `this[0]`', () => {
+		test('should be able to force subtrees to be static', () => {
+			function wrapH(h) {
+				return function(type, props, ...children) {
+					if (props['@static']) {
+						this[0] &= ~3;
+					}
+					return h(type, props, ...children);
+				};
+			}
+
+			const html = htm.bind(wrapH(h));
+			const x = () => html`<div @static>${'a'}</div>`;
+			const a = x();
+			const b = x();
+			expect(a).toEqual({ tag: 'div', props: { '@static': true }, children: ['a'] });
+			expect(b).toEqual({ tag: 'div', props: { '@static': true }, children: ['a'] });
+			expect(a).toBe(b);
+		});
+	});
 });

--- a/test/statics-caching.test.mjs
+++ b/test/statics-caching.test.mjs
@@ -91,22 +91,36 @@ describe('htm', () => {
 	});
 
 	describe('the h function should be able to modify `this[0]`', () => {
-		test('should be able to force subtrees to be static', () => {
-			function wrapH(h) {
-				return function(type, props, ...children) {
-					if (props['@static']) {
-						this[0] &= ~3;
-					}
-					return h(type, props, ...children);
-				};
-			}
+		function wrapH(h) {
+			return function(type, props, ...children) {
+				if (type === '@static') {
+					this[0] &= ~3;
+					return children;
+				}
+				if (props['@static']) {
+					this[0] &= ~3;
+				}
+				return h(type, props, ...children);
+			};
+		}
 
+		test('should be able to force subtrees to be static via a prop', () => {
 			const html = htm.bind(wrapH(h));
 			const x = () => html`<div @static>${'a'}</div>`;
 			const a = x();
 			const b = x();
 			expect(a).toEqual({ tag: 'div', props: { '@static': true }, children: ['a'] });
 			expect(b).toEqual({ tag: 'div', props: { '@static': true }, children: ['a'] });
+			expect(a).toBe(b);
+		});
+
+		test('should be able to force subtrees to be static via a special tag', () => {
+			const html = htm.bind(wrapH(h));
+			const x = () => html`<@static>${'a'}<//>`;
+			const a = x();
+			const b = x();
+			expect(a).toEqual(['a']);
+			expect(b).toEqual(['a']);
 			expect(a).toBe(b);
 		});
 	});


### PR DESCRIPTION
This pull request adds a test, checking that the `h` function can modify the staticness flags in `this[0]` to explicitly tell HTM to consider the current subtree as static.

The tests define a wrapper function for our `h` that flips the two lowest bits in `this[0]` to zero whenever we want to force the current subtree to be considered static:

```js
function wrapH(h) {
  return function(type, props, ...children) {
    if (type === '@static') {
      this[0] &= ~3;
      return children;
    }
    if (props['@static']) {
      this[0] &= ~3;
    }
    return h(type, props, ...children);
  };
}

const html = htm.bind(wrapH(h));
```

After this a magical `@static` prop allows forcing the subtree to be built only once:

```js
html`
  <div @static>
    <!-- do this once -->
    ${ items.map(x => <li>${x.name}</li>) }
  <//>
`
```

`@static` also works as a tag name when we just want to create a fragment:

```js
html`
  <@static>
    <!-- do this once -->
    ${ items.map(x => <li>${x.name}</li>) }
  <//>
`
```