### PR TITLE
Fix typing: export the identified w/ declared type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
-export default {
+declare const htm: {
   bind<HResult>(
     h: (type: any, props: Record<string, any>, ...children: any[]) => HResult
   ): (strings: TemplateStringsArray, ...values: any[]) => HResult | HResult[];
 };
+export default htm;


### PR DESCRIPTION
Resolves #152.

`index.d.ts` should export the identified value with declared type, not the actual type.