### PR TITLE
Fix render() in standalone build (fixes #159)

### DIFF
--- a/src/integrations/preact/standalone.mjs
+++ b/src/integrations/preact/standalone.mjs
@@ -11,13 +11,9 @@
  * limitations under the License.
  */
 
-import { h, Component, createContext, render as preactRender } from 'preact';
+import { h, Component, createContext, render } from 'preact';
 import { useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue } from 'preact/hooks';
 import htm from '../../index.mjs';
-
-function render(tree, parent) {
-	preactRender(tree, parent, parent.firstElementChild);
-}
 
 const html = htm.bind(h);
 

--- a/test/preact.test.mjs
+++ b/test/preact.test.mjs
@@ -61,8 +61,12 @@ describe('htm/preact', () => {
 		document.querySelector('button').click();
 		document.querySelector('button').click();
 		setTimeout(() => {
-			expect(scratch.innerHTML).toBe(fullHtml.replace('jason', 'tom').replace(/\b0\b/g, '2'));
-			done();
+			try {
+				expect(scratch.innerHTML).toBe(fullHtml.replace('jason', 'tom').replace(/\b0\b/g, '2'));
+			}
+			finally {
+				done();
+			}
 		});
 	});
 

--- a/test/preact.test.mjs
+++ b/test/preact.test.mjs
@@ -13,6 +13,8 @@
 
 import { html, Component, render } from 'htm/preact';
 
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
 describe('htm/preact', () => {
 	const scratch = document.createElement('div');
 	document.body.appendChild(scratch);
@@ -57,17 +59,11 @@ describe('htm/preact', () => {
 		expect(scratch.innerHTML).toBe(fullHtml.replace('jason', 'tom'));
 	});
 
-	test('state update re-renders', done => {
+	test('state update re-renders', async () => {
 		document.querySelector('button').click();
 		document.querySelector('button').click();
-		setTimeout(() => {
-			try {
-				expect(scratch.innerHTML).toBe(fullHtml.replace('jason', 'tom').replace(/\b0\b/g, '2'));
-			}
-			finally {
-				done();
-			}
-		});
+		await sleep(1);
+		expect(scratch.innerHTML).toBe(fullHtml.replace('jason', 'tom').replace(/\b0\b/g, '2'));
 	});
 
 	test('preserves case', () => {


### PR DESCRIPTION
I had "patched" the Preact integrations to automatically pass `replaceNode` for Preact 8 when we initially launched HTM. When we updated to Preact X, that patch was [correctly removed](https://github.com/developit/htm/commit/66f8ef8650f2a93627ea800eabc6006c82562f23#diff-3b5071effb1fb5ba4fe6eb2fdd26680bL17-L20) for `htm/preact`, but we forgot `htm/preact/standalone`. This just copies that change over, and fixes #159.

See [additional codepen repro](https://codepen.io/developit/pen/VwvebLQ?editors=0010) (line 55)