### PR TITLE
Support node v13 with es modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # Change the condition for ESM Dist Test below when changing this.
         node-version: [10.x, 12.x, 14.x]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install
-      run: npm install
-    - name: Build and Test
-      run: npm test
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: npm install
+      - name: Build and Test
+        run: npm test
+      - if: matrix.node-version == '14.x'
+        name: ESM Dist Test
+        run: npm run test:dist

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package-lock.json
 dist
 mini
 yarn.lock
+htm.tgz

--- a/package.json
+++ b/package.json
@@ -6,6 +6,39 @@
   "umd:main": "dist/htm.umd.js",
   "module": "dist/htm.module.js",
   "types": "dist/htm.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/htm.mjs",
+      "require": "./dist/htm.js",
+      "browser": "./dist/htm.module.js",
+      "umd": "./dist/htm.umd.js"
+    },
+    "./": "./",
+    "./preact": {
+      "import": "./preact/index.mjs",
+      "require": "./preact/index.js",
+      "browser": "./preact/index.module.js",
+      "umd": "./preact/index.umd.js"
+    },
+    "./preact/standalone": {
+      "import": "./preact/standalone.mjs",
+      "require": "./preact/standalone.js",
+      "browser": "./preact/standalone.module.js",
+      "umd": "./preact/standalone.umd.js"
+    },
+    "./react": {
+      "import": "./react/index.mjs",
+      "require": "./react/index.js",
+      "browser": "./react/index.module.js",
+      "umd": "./react/index.umd.js"
+    },
+    "./mini": {
+      "import": "./mini/index.mjs",
+      "require": "./mini/index.js",
+      "browser": "./mini/index.module.js",
+      "umd": "./mini/index.umd.js"
+    }
+  },
   "scripts": {
     "build": "npm run -s build:main && npm run -s build:mini && npm run -s build:preact && npm run -s build:react && npm run -s build:babel && npm run -s build:babel-transform-jsx && npm run -s build:mjsalias",
     "build:main": "microbundle src/index.mjs -f es,umd --no-sourcemap --target web && microbundle src/cjs.mjs -f iife --no-sourcemap --target web && cp src/index.d.ts dist/htm.d.ts",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
     "build:babel": "cd packages/babel-plugin-htm && npm run build",
     "build:babel-transform-jsx": "cd packages/babel-plugin-transform-jsx-to-htm && npm run build",
     "build:mjsalias": "cp dist/htm.module.js dist/htm.mjs && cp mini/index.module.js mini/index.mjs && cp preact/index.module.js preact/index.mjs && cp preact/standalone.module.js preact/standalone.mjs && cp react/index.module.js react/index.mjs",
-    "test": "eslint src/**/*.mjs test/**/*.mjs && npm run build && jest test",
+    "test": "eslint src/**/*.mjs test/**/*.mjs --ignore-path .gitignore && npm run build && jest test",
     "test:perf": "v8 test/__perftest.mjs",
+    "test:dist": "npm pack && mv htm*.tgz test/fixtures/esm/htm.tgz && cd test/fixtures/esm && npm install && node index.js",
     "release": "npm t && git commit -am \"$npm_package_version\" && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "files": [

--- a/test/fixtures/esm/index.js
+++ b/test/fixtures/esm/index.js
@@ -1,0 +1,5 @@
+import "htm";
+import "htm/preact";
+import "htm/preact/standalone";
+// TODOD: Enable once react distro is ESM compatible.
+// import "htm/react";

--- a/test/fixtures/esm/index.js
+++ b/test/fixtures/esm/index.js
@@ -1,5 +1,14 @@
-import "htm";
-import "htm/preact";
-import "htm/preact/standalone";
-// TODOD: Enable once react distro is ESM compatible.
-// import "htm/react";
+import assert from 'assert';
+import htm from 'htm';
+import * as preact from 'htm/preact';
+import * as standalone from 'htm/preact/standalone';
+// TODO: Enable once react distro is ESM compatible.
+// import * as react 'htm/react';
+
+assert(typeof htm === 'function', 'import htm from "htm"');
+
+assert(typeof preact.html === 'function', 'import { html } from "preact"');
+
+assert(typeof standalone.html === 'function', 'import { html } from "preact/standalone"');
+
+console.log('✅ Dist Tests Passed');

--- a/test/fixtures/esm/package.json
+++ b/test/fixtures/esm/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "htm_dist_test",
+  "type": "module",
+  "private": true,
+  "description": "A package to test importing htm as ES modules in Node",
+  "dependencies": {
+    "htm": "file:htm.tgz",
+    "preact": "^10.4.1"
+  }
+}


### PR DESCRIPTION
Creates conditional export that points "import" conditional exports to mjs files. This lets node load the esm version without having to set "type": "module" on the main package.json.

This is similar to the approach in the main preact repo - https://github.com/preactjs/preact/pull/2451