### PR TITLE
Export useErrorBoundary hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "eslint-config-developit": "^1.1.1",
     "jest": "^24.1.0",
     "microbundle": "^0.10.1",
-    "preact": "^10.0.0",
+    "preact": "^10.2.0",
     "react": "^16.8.3"
   }
 }

--- a/src/integrations/preact/standalone.mjs
+++ b/src/integrations/preact/standalone.mjs
@@ -12,9 +12,9 @@
  */
 
 import { h, Component, createContext, render } from 'preact';
-import { useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue } from 'preact/hooks';
+import { useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue, useErrorBoundary } from 'preact/hooks';
 import htm from '../../index.mjs';
 
 const html = htm.bind(h);
 
-export { h, html, render, Component, createContext, useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue };
+export { h, html, render, Component, createContext, useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue, useErrorBoundary };


### PR DESCRIPTION
This exposes the `useErrorBoundary` hook for the standalone preact bundle.