### PR TITLE
Collapse whitespace when { terse: true }

### DIFF
--- a/packages/babel-plugin-transform-jsx-to-htm/index.mjs
+++ b/packages/babel-plugin-transform-jsx-to-htm/index.mjs
@@ -4,13 +4,14 @@ import jsx from '@babel/plugin-syntax-jsx';
  * @param {Babel} babel
  * @param {object} [options]
  * @param {string} [options.tag='html']  The tagged template "tag" function name to produce.
- * @param {boolean} [options.terse=false]  Output `<//>` for closing component tags
+ * @param {boolean} [options.terse=false]  Collapse whitespace and use `<//>` for closing component tags
  * @param {string | boolean | object} [options.import=false]  Import the tag automatically
  */
 export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 	const tagString = options.tag || 'html';
 	const tag = dottedIdentifier(tagString);
 	const importDeclaration = tagImport(options.import || false);
+	const terse = options.terse === true;
 
 	function tagImport(imp) {
 		if (imp === false) {
@@ -118,8 +119,9 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 			for (let i = 0; i < children.length; i++) {
 				let child = children[i];
 				if (t.isStringLiteral(child)) {
-					// @todo - expose `whitespace: true` option?
-					escapeText(child.value);
+					let value = child.value;
+					if (terse) value = value.replace(/\n+/g, ' ');
+					escapeText(value);
 				}
 				else if (t.isJSXElement(child)) {
 					processNode(child);
@@ -131,7 +133,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 
 			if (!isFragment) {
 				if (isComponentName(name)) {
-					if (options.terse) {
+					if (terse) {
 						raw('<//>');
 					}
 					else {


### PR DESCRIPTION
This makes `terse:true` match Babel's [default JSX whitespace behaviors](https://babeljs.io/repl#?browsers=&build=&builtIns=false&spec=true&loose=false&code_lz=PTAEAECsGcA9QBYCgkB4AmBLAbgPiaKAIYDeA5AEZkC-AxmsFngNwoY76FGjlXWj1UjDqzRNOxQoQpSBBUOnmyApkgBmDcaNQAHAE7KJ3KTKn1Ci2YVUah-w9vHzU3YLh6Uag4SzZPCLqBuoKgybpoifhzOrhKhQfhCWlF4MQlIMqi06UmRYtEBsaAUztnhub5ocUXx5W6iQA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=true&timeTravel=false&sourceType=module&lineWrap=true&presets=react&prettier=false&targets=&version=7.12.10&externalPlugins=).

/cc @cristianbote