### PR TITLE
corrected React ESM import

### DIFF
--- a/src/integrations/react/index.mjs
+++ b/src/integrations/react/index.mjs
@@ -11,6 +11,6 @@
  * limitations under the License.
  */
 
-import { createElement } from 'react';
+import React from 'react';
 import htm from 'htm';
-export const html = htm.bind(createElement);
+export const html = htm.bind(React.createElement);


### PR DESCRIPTION
WMR won't currently properly import React as it gives the message "The requested module '/@npm/react' does not provide an export named 'createElement'". This fixes this.