### PR TITLE
Ensure that template literals generated by JSX-to-HTM transform has a balanced amount of quasis and expressions

### DIFF
--- a/packages/babel-plugin-transform-jsx-to-htm/index.mjs
+++ b/packages/babel-plugin-transform-jsx-to-htm/index.mjs
@@ -51,7 +51,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 
 	function expr(value) {
 		expressions.push(value);
-		quasis.push(t.templateElement({	raw: '', cooked: '' }));
+		quasis.push(t.templateElement({ raw: '', cooked: '' }));
 	}
 
 	function raw(str) {
@@ -199,7 +199,7 @@ export default function jsxToHtmBabelPlugin({ types: t }, options = {}) {
 		let quasisBefore = quasis;
 		let expressionsBefore = expressions;
 	
-		quasis = [t.templateElement({	raw: '', cooked: '' })];
+		quasis = [t.templateElement({ raw: '', cooked: '' })];
 		expressions = [];
 	
 		if (isFragment) {

--- a/test/babel-transform-jsx.test.mjs
+++ b/test/babel-transform-jsx.test.mjs
@@ -177,6 +177,12 @@ describe('babel-plugin-transform-jsx-to-htm', () => {
 				compile(`<React.Fragment>{Foo}{Bar}</React.Fragment>`)
 			).toBe('html`${Foo}${Bar}`;');
 		});
+
+		test('short syntax fragments should not crash due to TemplateLiteral quasi/expression unbalance', () => {
+			expect(
+				compile(`<><Foo />{Bar}</>`)
+			).toBe('html`<${Foo}/>${Bar}`;');
+		});		
 	});
 
 	describe('props', () => {

--- a/test/babel-transform-jsx.test.mjs
+++ b/test/babel-transform-jsx.test.mjs
@@ -182,7 +182,7 @@ describe('babel-plugin-transform-jsx-to-htm', () => {
 			expect(
 				compile(`<><Foo />{Bar}</>`)
 			).toBe('html`<${Foo}/>${Bar}`;');
-		});		
+		});
 	});
 
 	describe('props', () => {


### PR DESCRIPTION
This pull request fixes the babel-plugin-transform-jsx-to-htm plugin output for JSX inputs like this:

```jsx
<>
  <Foo />
  {Bar}
</>
```

Before the fix the plugin crashes with the following error message:

```
Number of TemplateLiteral quasis should be exactly one more than the number of expressions.
Expected 3 quasis but got 2
```

The fix is to always ensure that a template literal expression ends with a quasi, even when the quasi is an empty string. New static string content is then always applied to the (currently) last quasi in the template. When an expression is added a new empty quasi is immediately appended after that.

Kudos to @cristianbote for noticing a problem on [wmr](https://github.com/preactjs/wmr) output that was caused by this issue. It appears that this fix also fixes the wmr problem.

This pull request also adds a test illustrating the problem.