### PR TITLE
Reorder exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
       "import": "./dist/htm.mjs",
       "require": "./dist/htm.js"
     },
+    "./": "./",
     "./preact": {
       "browser": "./preact/index.module.js",
       "umd": "./preact/index.umd.js",
@@ -36,8 +37,7 @@
       "umd": "./mini/index.umd.js",
       "import": "./mini/index.mjs",
       "require": "./mini/index.js"
-    },
-    "./": "./"
+    }
   },
   "scripts": {
     "build": "npm run -s build:main && npm run -s build:mini && npm run -s build:preact && npm run -s build:react && npm run -s build:babel && npm run -s build:babel-transform-jsx && npm run -s build:mjsalias",

--- a/package.json
+++ b/package.json
@@ -8,35 +8,35 @@
   "types": "dist/htm.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/htm.mjs",
-      "require": "./dist/htm.js",
       "browser": "./dist/htm.module.js",
-      "umd": "./dist/htm.umd.js"
+      "umd": "./dist/htm.umd.js",
+      "import": "./dist/htm.mjs",
+      "require": "./dist/htm.js"
     },
     "./": "./",
     "./preact": {
-      "import": "./preact/index.mjs",
-      "require": "./preact/index.js",
       "browser": "./preact/index.module.js",
-      "umd": "./preact/index.umd.js"
+      "umd": "./preact/index.umd.js",
+      "import": "./preact/index.mjs",
+      "require": "./preact/index.js"
     },
     "./preact/standalone": {
-      "import": "./preact/standalone.mjs",
-      "require": "./preact/standalone.js",
       "browser": "./preact/standalone.module.js",
-      "umd": "./preact/standalone.umd.js"
+      "umd": "./preact/standalone.umd.js",
+      "import": "./preact/standalone.mjs",
+      "require": "./preact/standalone.js"
     },
     "./react": {
-      "import": "./react/index.mjs",
-      "require": "./react/index.js",
       "browser": "./react/index.module.js",
-      "umd": "./react/index.umd.js"
+      "umd": "./react/index.umd.js",
+      "import": "./react/index.mjs",
+      "require": "./react/index.js"
     },
     "./mini": {
-      "import": "./mini/index.mjs",
-      "require": "./mini/index.js",
       "browser": "./mini/index.module.js",
-      "umd": "./mini/index.umd.js"
+      "umd": "./mini/index.umd.js",
+      "import": "./mini/index.mjs",
+      "require": "./mini/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Reference: https://github.com/jspm/project/issues/100#issuecomment-810644748

Hi, I find an issue with my package's exports and looks like it applies `htm` too. 

Preact also keeps them in that order https://github.com/preactjs/preact/blob/master/package.json