### PR TITLE
Fixed babel-plugin-htm's documentation of `import` options

### DIFF
--- a/packages/babel-plugin-htm/README.md
+++ b/packages/babel-plugin-htm/README.md
@@ -60,7 +60,7 @@ With Babel config:
 "plugins": [
   ["babel-plugin-htm", {
     "tag": "$$html",
-    "import": "preact"
+    "import": "htm/preact"
   }]
 ]
 ```


### PR DESCRIPTION
I just tried this in our repo, and it works just fine. The `import` property is taken verbatim into the transformed code (fortunately!).