### PR TITLE
Ignore JS-style comments during parse

### DIFF
--- a/src/build.mjs
+++ b/src/build.mjs
@@ -5,8 +5,10 @@ const MODE_TEXT = 1;
 const MODE_WHITESPACE = 2;
 const MODE_TAGNAME = 3;
 const MODE_COMMENT = 4;
-const MODE_PROP_SET = 5;
-const MODE_PROP_APPEND = 6;
+const MODE_COMMENT_SINGLE = 5;
+const MODE_COMMENT_MULTI = 6;
+const MODE_PROP_SET = 7;
+const MODE_PROP_APPEND = 8;
 
 const CHILD_APPEND = 0;
 const CHILD_RECURSE = 2;
@@ -219,6 +221,26 @@ export const build = function(statics) {
 				}
 				else {
 					buffer += char;
+				}
+			}
+			else if (mode === MODE_WHITESPACE && char === '/' && statics[i][j+1] === '/') {
+				mode = MODE_COMMENT_SINGLE;
+			}
+			else if (mode === MODE_WHITESPACE && char === '/' && statics[i][j+1] === '*') {
+				mode = MODE_COMMENT_MULTI;
+			}
+			else if (mode === MODE_COMMENT_SINGLE) {
+				// Ignore everything until newline
+				if (char === '\n' || char === '\r') {
+					mode = MODE_WHITESPACE;
+					buffer = '';
+				}
+			}
+			else if (mode === MODE_COMMENT_MULTI) {
+				if (char === '*' && statics[i][j+1] === '/') {
+					mode = MODE_WHITESPACE;
+					buffer = '';
+					j++;
 				}
 			}
 			else if (mode === MODE_COMMENT) {

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -215,4 +215,34 @@ describe('htm', () => {
 		expect(html`<a><!-- ${'Hello, world!'} --></a>`).toEqual(h('a', null));
 		expect(html`<a><!--> Hello, world <!--></a>`).toEqual(h('a', null));
 	});
+
+	test('ignore JS single line comments', () => {
+		expect(html`<div
+			// comment
+			id="foo" />`).toEqual(h('div', { id: 'foo' }));
+		expect(html`<div id="foo"
+			// comment
+			/>`).toEqual(h('div', { id: 'foo' }));
+		expect(html`<div id="foo" //comment
+			/>`).toEqual(h('div', { id: 'foo' }));
+
+		// False positives
+		expect(html`<div id="// foo"
+			/>`).toEqual(h('div', { id: '// foo' }));
+		expect(html`<div>// no comment</div>`).toEqual(h('div', null, '// no comment'));
+	});
+
+	test('ignore JS multi line comments', () => {
+		expect(html`<div
+			/* comment */
+			id="foo" />`).toEqual(h('div', { id: 'foo' }));
+		expect(html`<div id="foo"
+			/* comment */
+			/>`).toEqual(h('div', { id: 'foo' }));
+		expect(html`<div id="foo" /* comment */ />`).toEqual(h('div', { id: 'foo' }));
+
+		// False positives
+		expect(html`<div id="/* foo */" />`).toEqual(h('div', { id: '/* foo */' }));
+		expect(html`<div>/*foo*/</div>`).toEqual(h('div', null, '/*foo*/'));
+	});
 });


### PR DESCRIPTION
This PR enhances htm's parser to detect and ignore JS-style comments, similar to JSX.

```js
// Multi line
html`<div /* I'm ignored */ id="foo" />`

// Single line
html`<div // I'm ignored
  id="foo" />`
```

Fixes #213