### PR TITLE
Skip running tests on outdated Node 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         # Change the condition for ESM Dist Test below when changing this.
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Node 12 has been the oldest LTS for a while now.