### PR TITLE
Fix nodenext module support from TypeScript 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "dist/htm.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/htm.d.ts",
       "browser": "./dist/htm.module.js",
       "umd": "./dist/htm.umd.js",
       "import": "./dist/htm.mjs",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "dist/htm.d.ts",
   "exports": {
     ".": {
+      "types": "./src/index.d.ts",
       "browser": "./dist/htm.module.js",
       "umd": "./dist/htm.umd.js",
       "import": "./dist/htm.mjs",
@@ -15,24 +16,28 @@
     },
     "./": "./",
     "./preact": {
+      "types": "./preact/index.d.ts",
       "browser": "./preact/index.module.js",
       "umd": "./preact/index.umd.js",
       "import": "./preact/index.mjs",
       "require": "./preact/index.js"
     },
     "./preact/standalone": {
+      "types": "./preact/index.d.ts",
       "browser": "./preact/standalone.module.js",
       "umd": "./preact/standalone.umd.js",
       "import": "./preact/standalone.mjs",
       "require": "./preact/standalone.js"
     },
     "./react": {
+      "types": "./react/index.d.ts",
       "browser": "./react/index.module.js",
       "umd": "./react/index.umd.js",
       "import": "./react/index.mjs",
       "require": "./react/index.js"
     },
     "./mini": {
+      "types": "./mini/index.d.ts",
       "browser": "./mini/index.module.js",
       "umd": "./mini/index.umd.js",
       "import": "./mini/index.mjs",


### PR DESCRIPTION
* as per https://github.com/microsoft/TypeScript/issues/48235#issuecomment-1067363731
* follow-up https://github.com/preactjs/preact/pull/3513