### PR TITLE
Add createRef to standalone preact bundle

### DIFF
--- a/src/integrations/preact/standalone.mjs
+++ b/src/integrations/preact/standalone.mjs
@@ -11,10 +11,10 @@
  * limitations under the License.
  */
 
-import { h, Component, createContext, render } from 'preact';
+import { h, Component, createContext, createRef, render } from 'preact';
 import { useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue, useErrorBoundary } from 'preact/hooks';
 import htm from '../../index.mjs';
 
 const html = htm.bind(h);
 
-export { h, html, render, Component, createContext, useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue, useErrorBoundary };
+export { h, html, render, Component, createContext, createRef, useState, useReducer, useEffect, useLayoutEffect, useRef, useImperativeHandle, useMemo, useCallback, useContext, useDebugValue, useErrorBoundary };


### PR DESCRIPTION
This exposes `createRef` for the standalone preact bundle.
