### PR TITLE
export hooks

### DIFF
--- a/src/integrations/preact/index.mjs
+++ b/src/integrations/preact/index.mjs
@@ -13,6 +13,7 @@
 
 import { h, Component, render } from 'preact';
 import htm from 'htm';
+export * from 'preact/hooks';
 
 const html = htm.bind(h);
 


### PR DESCRIPTION
`hooks` was [exported in the type definition file](https://github.com/developit/htm/blob/master/src/integrations/preact/index.d.ts#L2), but not in the source code.